### PR TITLE
small fix for a JS error

### DIFF
--- a/lua/ge/extensions/UI.lua
+++ b/lua/ge/extensions/UI.lua
@@ -93,7 +93,7 @@ local function showNotification(text, type)
 	else
 		print("[Message] > "..text)
 	end
-	ui_message(''..text, 10, 0, 0)
+	ui_message(''..text, 10, nil, nil)
 end
 
 


### PR DESCRIPTION
this fixes JS error in console when players join a server, where the message is supposed to show in the top left (ie. "guest0123456 joined the game!"), and therefore restores that message appearing, and I guess would ensure any other MP notifications that take place there are shown.