### PR TITLE
Fix for reconnecting bug with launcher

### DIFF
--- a/lua/ge/extensions/MPCoreNetwork.lua
+++ b/lua/ge/extensions/MPCoreNetwork.lua
@@ -341,6 +341,7 @@ end
 
 
 local function onUpdate(dt)
+	launcherTimeout = 0
 	--print(launcherConnectionTimer)
 	--====================================================== DATA RECEIVE ======================================================
 	if launcherConnectionStatus > 0 then -- If player is connecting or connected


### PR DESCRIPTION
This fixes a bug where, after briefly disconnecting, the launcher repeatedly tries to reconnect.

I don't know if this is the same issue as the issue we've been seeing for months, it might be.