### PR TITLE
Fix: table server list width greater than view on small display

### DIFF
--- a/ui/modules/multiplayer/login.partial.html
+++ b/ui/modules/multiplayer/login.partial.html
@@ -1,4 +1,4 @@
-<link type="text/css" rel="stylesheet" href="modules/multiplayer/multiplayer.css">
+<link type="text/css" rel="stylesheet" href="ui/modules/multiplayer/multiplayer.css">
 
 
 <div style="height:100%; background-color: rgba(0, 0, 0, 0.50);">

--- a/ui/modules/multiplayer/multiplayer.css
+++ b/ui/modules/multiplayer/multiplayer.css
@@ -37,6 +37,15 @@ table#serversTable {
   transition: 0.2s;
 }
 
+#serversTable th, #serversTable td{
+  flex: 1;
+}
+
+#serversTable tr{
+  display: flex;
+  flex-direction: row;
+}
+
 #serversTable th:hover {
   background-color: rgba(0, 0, 0, 0.25);
 }


### PR DESCRIPTION
Simple modification, using flexboxes but does not respect the proportions of the columns