### PR TITLE
Fix login json string not escaping properly

### DIFF
--- a/lua/ge/extensions/MPCoreNetwork.lua
+++ b/lua/ge/extensions/MPCoreNetwork.lua
@@ -108,8 +108,8 @@ local function isLauncherConnected()
 	return launcherConnectionStatus == 2
 end
 local function login(identifiers)
-	log('M', 'login', 'Attempting login')
-	send('N:'..identifiers)
+	log('M', 'login', 'Attempting login...')
+	send('N:'..jsonEncode(identifiers))
 end
 local function autoLogin()
 	send('Nc')
@@ -249,11 +249,11 @@ local function loginReceived(params)
 	log('M', 'loginReceived', 'Logging result received')
 	local result = jsonDecode(params)
 	if (result.success == true or result.Auth == 1) then
-		log('M', 'loginReceived', 'Login successful')
+		log('M', 'loginReceived', 'Login successful.')
 		loggedIn = true
 		guihooks.trigger('LoggedIn', result.message or '')
 	else
-		log('M', 'loginReceived', 'Login credentials incorrect')
+		log('M', 'loginReceived', 'Login failed.')
 		loggedIn = false
 		guihooks.trigger('LoginError', result.message or '')
 	end

--- a/ui/modules/multiplayer/multiplayer.js
+++ b/ui/modules/multiplayer/multiplayer.js
@@ -71,15 +71,16 @@ function($scope, $state, $timeout, $document) {
 	// for that reason, we listen for the settings changed event that will ensure that the main menu will not get back here again
 	var vm = this;
 	$scope.login = function() {
-		var u = document.getElementById('loginUsername').value.trim();
-		var p = document.getElementById('loginPassword').value.trim();
-		if (u == "" || p == ""){
+		let credentials = {}
+		credentials.username = document.getElementById('loginUsername').value.trim();
+		credentials.password = document.getElementById('loginPassword').value.trim();
+		if (credentials.username == "" || credentials.password == ""){
 			document.getElementById('loginHeader').textContent = 'Missing credentials';
 			return;
 		}	
 		document.getElementById('loginPassword').value = '';
 		document.getElementById('loginHeader').textContent = 'Attempting to log in...';
-		bngApi.engineLua("MPCoreNetwork.login('" + JSON.stringify({ username: u, password: p }) + "')");
+		bngApi.engineLua('MPCoreNetwork.login(' + bngApi.serializeToLua(credentials) + ')');
 	}
 
 	$scope.switchConnection = function() {


### PR DESCRIPTION
json.stringify doesn't properly escape `' "` (and some other) characters which causes the login to fail.
Fixed by serializing the data to lua and then doing a jsonEncode from there.

Tested with a few different passwords which contain characters that previously caused issues and they all work as expected.