### PR TITLE
stop mp gamestate from loading in freeroam

### DIFF
--- a/lua/ge/extensions/multiplayer/multiplayer.lua
+++ b/lua/ge/extensions/multiplayer/multiplayer.lua
@@ -105,8 +105,6 @@ end
 
 local function onClientPostStartMission()
 	if MPCoreNetwork.isMPSession() then
-		core_gamestate.setGameState('multiplayer', 'multiplayer', 'multiplayer') -- This is added to set the UI elements
-		log('M', 'onClientPostStartMission', 'Setting game state to multiplayer.')
 		MPGameNetwork.connectToLauncher()
 	end
 end
@@ -210,7 +208,10 @@ local function onUpdate(dt)
 		-- Workaround for worldReadyState not being set properly if there are no vehicles
 		serverConnection.onCameraHandlerSetInitial()
 		extensions.hook('onCameraHandlerSet')
-		core_gamestate.setGameState('multiplayer', 'multiplayer', 'multiplayer') -- This is added to set the UI elements
+		if MPCoreNetwork and MPCoreNetwork.isMPSession() then
+			log('M', 'onUpdate', 'Setting game state to multiplayer.')
+			core_gamestate.setGameState('multiplayer', 'multiplayer', 'multiplayer') -- This is added to set the UI elements
+		end
   end
 end
 

--- a/ui/modules/mp_mainmenu/mainmenu.js
+++ b/ui/modules/mp_mainmenu/mainmenu.js
@@ -124,7 +124,7 @@ angular.module('beamng.stuff')
       scope.showBuildInfo = false
       scope.versionStr = beamng.version
       // TODO #203 Fix this to actually use the real launcher version!
-      scope.beammpGameVer = '4.6.0'
+      scope.beammpGameVer = '4.6.1'
       scope.beammpLauncherVer = '3.0.0'
 
       // convert from 1.2.3.4 to 1.2.3 as we do not want to attach the build number in the simple display


### PR DESCRIPTION
Currently we completely break the freeroam mode if BeamMP is loaded since https://github.com/BeamMP/BeamMP/pull/239
(MP UI is loaded instead of the freeroam one, and missions don't appear / big map mode doesn't work)
This addresses that issue.