### PR TITLE
fix onExtensionUnloaded() not being called on exit

### DIFF
--- a/lua/ge/extensions/MPModManager.lua
+++ b/lua/ge/extensions/MPModManager.lua
@@ -20,7 +20,7 @@ local cleanuptimer = 0
 
 
 --this should be every extension that might possibly be running, EXCEPT for the extensions loaded by mods on the server.
---putting them in this table to be used by extensions.unloadExcept() effectively means ONLY extensions loaded by mods on a server will have onExtensionUnloaded 
+--putting them in this table to be used by extensions.unloadExcept() effectively means ONLY extensions loaded by mods on a server will have onExtensionUnloaded() called
 local extensionExceptions = {
 	'MPConfig', 'MPCoreNetwork', 'MPDebug', 'MPElectricsGE', 'MPGameNetwork', 'MPHelpers', 'MPInputsGE', 'MPModManager', 'MPPowertrainGE', 'MPUpdatesGE', 'MPVehicleGE', 'multiplayer_multiplayer', 'nodesGE', 'positionGE', 'UI',
 	'campaign_campaignsLoader',

--- a/lua/ge/extensions/MPModManager.lua
+++ b/lua/ge/extensions/MPModManager.lua
@@ -19,6 +19,25 @@ local cleanuptimer = 0
 
 
 
+--this should be everything except the extensions loaded by mods on the server. Probably a cleaner way to obtain this.
+local extensionExceptions = {
+	'MPConfig', 'MPCoreNetwork', 'MPDebug', 'MPElectricsGE', 'MPGameNetwork', 'MPHelpers', 'MPInputsGE', 'MPModManager', 'MPPowertrainGE', 'MPUpdatesGE', 'MPVehicleGE', 'multiplayer_multiplayer', 'nodesGE', 'positionGE', 'UI',
+	'campaign_campaignsLoader',
+	'career_branches', 'career_career', 'career_saveSystem',
+	'core_activityManager', 'core_audio', 'core_camera', 'core_commandhandler', 'core_environment', 'core_flowgraphManager', 'core_forest', 'core_gameContext', 'core_gamestate', 'core_groundMarkers', 'core_hardwareinfo', 'core_highscores', 	'core_input_actionFilter', 'core_input_actions', 'core_input_bindings', 'core_input_categories', 'core_input_deprecatedActions', 'core_input_vehicleSwitching', 'core_input_virtualInput', 'core_inventory', 'core_jobsystem', 'core_levels', 'core_metrics', 'core_modmanager', 'core_multiseat', 'core_multiSpawn', 'core_online', 'core_paths', 'core_quickAccess', 'core_remoteController', 'core_replay', 'core_repository', 'core_settings_audio', 'core_settings_gameplay', 'core_settings_graphic', 'core_settings_settings', 'core_sounds', 'core_terrain', 'core_vehicleBridge', 'core_vehiclePoolingManager', 'core_vehicles', 'core_vehicle_colors', 'core_vehicle_manager',
+	'editor_main',
+	'freeroam_bigMapMode', 'freeroam_facilities', 'freeroam_freeroam',
+	'gameplay_city', 'gameplay_garageMode', 'gameplay_missions_clustering', 'gameplay_missions_locationsDetector', 'gameplay_missions_missionEnter', 'gameplay_missions_missions', 'gameplay_missions_progress', 'gameplay_missions_startTrigger', 'gameplay_missions_unlocks', 'gameplay_parking', 'gameplay_police', 'gameplay_sites_sitesManager', 'gameplay_traffic',
+	'render_hdr',
+	'scenario_quickRaceLoader','scenario_scenariosLoader',
+	'tech_license',
+	'telemetry_gameTelemetry',
+	'trackbuilder_trackBuilder',
+	'ui_apps', 'ui_audio', 'ui_console', 'ui_fadeScreen', 'ui_flowgraph_editor', 'ui_gameBlur', 'ui_imgui', 'ui_missionInfo', 'ui_visibility'
+	}
+
+
+
 local function IsModAllowed(n)
 	for k,v in pairs(mods) do
 		if string.lower(v) == string.lower(n) then
@@ -86,6 +105,8 @@ end
 
 
 local function cleanUpSessionMods()
+	log('M', "cleanUpSessionMods", "Unloading all multiplayer mods' extensions")
+	extensions.unloadExcept(extensionExceptions) --call onExtensionUnloaded() for all current mod extensions that have this function
 	log('M', "cleanUpSessionMods", "Deleting all multiplayer mods")
 	local modsDB = jsonReadFile("mods/db.json")
 	if modsDB then

--- a/lua/ge/extensions/MPModManager.lua
+++ b/lua/ge/extensions/MPModManager.lua
@@ -19,7 +19,8 @@ local cleanuptimer = 0
 
 
 
---this should be everything except the extensions loaded by mods on the server. Probably a cleaner way to obtain this.
+--this should be every extension that might possibly be running, EXCEPT for the extensions loaded by mods on the server.
+--putting them in this table to be used by extensions.unloadExcept() effectively means ONLY extensions loaded by mods on a server will have onExtensionUnloaded 
 local extensionExceptions = {
 	'MPConfig', 'MPCoreNetwork', 'MPDebug', 'MPElectricsGE', 'MPGameNetwork', 'MPHelpers', 'MPInputsGE', 'MPModManager', 'MPPowertrainGE', 'MPUpdatesGE', 'MPVehicleGE', 'multiplayer_multiplayer', 'nodesGE', 'positionGE', 'UI',
 	'campaign_campaignsLoader',


### PR DESCRIPTION
makes sure `onExtensionUnloaded()` is called for all loaded mod extensions EXCEPT for those from BeamMP and the base game.