### PR TITLE
Add info about simplified vehicles reducing visual accuracy in tooltip

### DIFF
--- a/mp_locales/en-US.json
+++ b/mp_locales/en-US.json
@@ -34,7 +34,7 @@
     "ui.options.multiplayer.disableInstabilityPausing": "Disable pausing caused by instabilities",
     "ui.options.multiplayer.disableInstabilityPausing.tooltip": "This will make gameplay smoother but can cause sync issues after several instabilities",
     "ui.options.multiplayer.simplifyRemoteVehicles": "Use simplified vehicles when available",
-    "ui.options.multiplayer.simplifyRemoteVehicles.tooltip": "This setting will replace remote vehicles with the BeamNG provided 'traffic' versions. Reduces accuracy of collisions, but improves performance",
+    "ui.options.multiplayer.simplifyRemoteVehicles.tooltip": "This setting will replace remote vehicles with the BeamNG provided 'traffic' versions. Reduces accuracy of collisions and visuals, but improves performance",
     "ui.options.multiplayer.enableBlobs": "Enable blobs for unspawned vehicles",
     "ui.options.multiplayer.enableBlobs.tooltip": "Unspawned vehicles will appear as blobs",
     "ui.options.multiplayer.showSpectators": "Show spectators under vehicle nametags",


### PR DESCRIPTION
Extremely tiny and simple PR.

This can be confusing for some people, found the issue when one of my friends noticed he could not see my custom configuration on my car, so precising it in the tooltip will make it clearer.