### PR TITLE
BeamNG Player tags for BeamNG officials and affiliates

### DIFF
--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -37,8 +37,10 @@ local roleToInfo = {
 	['STAFF']	= { backcolor = ColorI(068, 109, 184, 127), tag = " [BeamMP Staff]", shorttag = " [Staff]" },
 	['MOD']		= { backcolor = ColorI(068, 109, 184, 127), tag = " [Moderator]", shorttag = " [Mod]" },
 	['ADM']		= { backcolor = ColorI(218, 000, 078, 127), tag = " [Admin]", shorttag = " [Adm]" },
-	['GDEV']	= { backcolor = ColorI(252, 107, 003, 127), tag = " [BeamNG Staff]", shorttag = " [BNG]" },
-	['MDEV']	= { backcolor = ColorI(194, 055, 055, 127), tag = " [BeamMP Dev]", shorttag = " [Dev]" }
+	['MDEV']	= { backcolor = ColorI(194, 055, 055, 127), tag = " [BeamMP Dev]", shorttag = " [Dev]" },
+	['NGDEV']	= { backcolor = ColorI(252, 107, 003, 127), tag = " [BeamNG Developer]", shorttag = " [BNG]" },
+	['NGSTAFF']	= { backcolor = ColorI(252, 107, 003, 127), tag = " [BeamNG Staff]", shorttag = " [BNG]" },
+	['NGAFFIL']	= { backcolor = ColorI(252, 107, 003, 127), tag = " [BeamNG Affiliate]", shorttag = " [BNG]" }
 }
 
 --[[Format - same as roleToInfo


### PR DESCRIPTION
Adds 3 new roles into roleToInfo that can be used to give beamng officials backend authorized player tags, if they so wish too.

Note: the GDEV role has been renamed to NGDEV and its tag changed from [BeamNG Staff] to [BeamNG Developer]

- NGDEV could be given to Game Developers of BeamNG
- NGSTAFF to company employees that are not Developers. Im thinking of Leeloo for example
- NGAFFIL to those that are affiliate to the company, like moderators on the Discord

