### PR TITLE
Fixes Camera Spawning underground in Italy

### DIFF
--- a/lua/ge/extensions/multiplayer/multiplayer.lua
+++ b/lua/ge/extensions/multiplayer/multiplayer.lua
@@ -104,15 +104,15 @@ local function onWorldReadyState(state)
 			core_gamestate.setGameState('multiplayer', 'multiplayer', 'multiplayer')
 			
             -- QUICK DIRTY PATCH FOR THE CAMERA SPAWNING UNDERGROUND FROM THE 0.28 UDPATE
-            local contents = jsonReadFile(getMissionPath() .. "main/MissionGroup/PlayerDropPoints/items.level.json") -- first vanilla path
+			local contents = jsonReadFile(getMissionPath() .. "main/MissionGroup/PlayerDropPoints/items.level.json") -- first vanilla path
 			
 			if contents == nil then
 				contents = jsonReadFile(getMissionPath() .. "main/MissionGroup/spawnpoints/items.level.json") -- alternate vanilla path
 			end
 
-            local position = contents["position"] or { 0, 0, 0 }
-            position[3] = position[3] + 2 -- otherwise the cam spawns in the ground
-            core_camera.setPosRot(0, position[1], position[2], position[3], 0, 0, 0, 0)
+			local position = contents["position"] or { 0, 0, 0 }
+			position[3] = position[3] + 2 -- otherwise the cam spawns in the ground
+			core_camera.setPosRot(0, position[1], position[2], position[3], 0, 0, 0, 0)
 		end
 	end
 end

--- a/lua/ge/extensions/multiplayer/multiplayer.lua
+++ b/lua/ge/extensions/multiplayer/multiplayer.lua
@@ -104,13 +104,14 @@ local function onWorldReadyState(state)
 			core_gamestate.setGameState('multiplayer', 'multiplayer', 'multiplayer')
 			
             -- QUICK DIRTY PATCH FOR THE CAMERA SPAWNING UNDERGROUND FROM THE 0.28 UDPATE
-            local contents = jsonReadFile(getMissionPath() .. "main/MissionGroup/PlayerDropPoints/items.level.json")
+            local contents = jsonReadFile(getMissionPath() .. "main/MissionGroup/PlayerDropPoints/items.level.json") -- first vanilla path
+			
+			if contents == nil then
+				contents = jsonReadFile(getMissionPath() .. "main/MissionGroup/spawnpoints/items.level.json") -- alternate vanilla path
+			end
 
             local position = contents["position"] or { 0, 0, 0 }
-
             position[3] = position[3] + 2 -- otherwise the cam spawns in the ground
-
-            -- local rotation = contents["rotationMatrix"] -- the info in this table can be borked, so we use 0 for all rotations
             core_camera.setPosRot(0, position[1], position[2], position[3], 0, 0, 0, 0)
 		end
 	end


### PR DESCRIPTION
Italy does not have the PlayerDropPoints folder in its contents, which makes it impossible for beammp to spawn the camera at the default location. This patch takes the spawnpoints from another file if the first, thats used by the other vanilla maps and modded maps, is not available.