### PR TITLE
Camera spawn fix

### DIFF
--- a/lua/ge/extensions/multiplayer/multiplayer.lua
+++ b/lua/ge/extensions/multiplayer/multiplayer.lua
@@ -96,28 +96,6 @@ local function onServerLeave()
 end
 
 
-local function NewSpawnFunc()
-	local new_spawn = scenetree.findObject(setSpawnpoint.loadDefaultSpawnpoint())
-	if new_spawn and new_spawn.obj then
-		local spawnPos = new_spawn.obj:getPosition()
-		core_camera.setPosRot(0, spawnPos.x, spawnPos.y, spawnPos.z + 3, 0, 0, 0, 0)
-		log('I', 'onWorldReadyState', 'NewSpawnFunc')
-		return true
-	end
-	return false
-end
-
-local function DefaultSpawnFunc()
-	local contents = jsonReadFile(getMissionPath() .. "main/MissionGroup/PlayerDropPoints/items.level.json")
-	local position = contents and contents["position"]
-	if position then
-		core_camera.setPosRot(0, position[1], position[2], position[3] + 3, 0, 0, 0, 0)
-		log('I', 'onWorldReadyState', 'DefaultSpawnFunc')
-		return true
-	end
-	return false
-end
-
 local function onWorldReadyState(state)
 	log('W', 'onWorldReadyState', state)
 	if state == 2 then
@@ -125,8 +103,10 @@ local function onWorldReadyState(state)
 			log('M', 'onWorldReadyState', 'Setting game state to multiplayer.')
 			core_gamestate.setGameState('multiplayer', 'multiplayer', 'multiplayer')
 
-			if not DefaultSpawnFunc() then
-				NewSpawnFunc()
+			local new_spawn = scenetree.findObject(setSpawnpoint.loadDefaultSpawnpoint())
+			if new_spawn and new_spawn.obj then
+				local spawnPos = new_spawn.obj:getPosition()
+				core_camera.setPosRot(0, spawnPos.x, spawnPos.y, spawnPos.z + 3, 0, 0, 0, 0)
 			end
 		end
 	end

--- a/lua/ge/extensions/multiplayer/multiplayer.lua
+++ b/lua/ge/extensions/multiplayer/multiplayer.lua
@@ -102,11 +102,31 @@ local function onWorldReadyState(state)
 		if MPCoreNetwork and MPCoreNetwork.isMPSession() then
 			log('M', 'onWorldReadyState', 'Setting game state to multiplayer.')
 			core_gamestate.setGameState('multiplayer', 'multiplayer', 'multiplayer')
+			local spawnDefaultGroups = { "CameraSpawnPoints", "PlayerSpawnPoints", "PlayerDropPoints", "spawnpoints" }
 
-			local new_spawn = scenetree.findObject(setSpawnpoint.loadDefaultSpawnpoint())
-			if new_spawn and new_spawn.obj then
-				local spawnPos = new_spawn.obj:getPosition()
+			for i, v in pairs(spawnDefaultGroups) do
+				if scenetree.findObject(spawnDefaultGroups[i]) then
+					local spawngroupPoint = scenetree.findObject(spawnDefaultGroups[i]):getRandom()
+					if not spawngroupPoint then
+						break
+					end
+					local sgPpointID = scenetree.findObjectById(spawngroupPoint:getId())
+					if not sgPpointID then
+						break
+					end
+					if sgPpointID and sgPpointID.obj then
+						local spawnPos = sgPpointID.obj:getPosition()
+						core_camera.setPosRot(0, spawnPos.x, spawnPos.y, spawnPos.z + 3, 0, 0, 0, 0)
+						return
+					end
+				end
+			end
+
+			local defaultSpawn = scenetree.findObject(setSpawnpoint.loadDefaultSpawnpoint())
+			if defaultSpawn and defaultSpawn.obj then
+				local spawnPos = defaultSpawn.obj:getPosition()
 				core_camera.setPosRot(0, spawnPos.x, spawnPos.y, spawnPos.z + 3, 0, 0, 0, 0)
+				return
 			end
 		end
 	end

--- a/lua/ge/extensions/multiplayer/multiplayer.lua
+++ b/lua/ge/extensions/multiplayer/multiplayer.lua
@@ -96,22 +96,38 @@ local function onServerLeave()
 end
 
 
+local function NewSpawnFunc()
+	local new_spawn = scenetree.findObject(setSpawnpoint.loadDefaultSpawnpoint())
+	if new_spawn and new_spawn.obj then
+		local spawnPos = new_spawn.obj:getPosition()
+		core_camera.setPosRot(0, spawnPos.x, spawnPos.y, spawnPos.z + 3, 0, 0, 0, 0)
+		log('I', 'onWorldReadyState', 'NewSpawnFunc')
+		return true
+	end
+	return false
+end
+
+local function DefaultSpawnFunc()
+	local contents = jsonReadFile(getMissionPath() .. "main/MissionGroup/PlayerDropPoints/items.level.json")
+	local position = contents and contents["position"]
+	if position then
+		core_camera.setPosRot(0, position[1], position[2], position[3] + 3, 0, 0, 0, 0)
+		log('I', 'onWorldReadyState', 'DefaultSpawnFunc')
+		return true
+	end
+	return false
+end
+
 local function onWorldReadyState(state)
 	log('W', 'onWorldReadyState', state)
 	if state == 2 then
 		if MPCoreNetwork and MPCoreNetwork.isMPSession() then
 			log('M', 'onWorldReadyState', 'Setting game state to multiplayer.')
 			core_gamestate.setGameState('multiplayer', 'multiplayer', 'multiplayer')
-			
-            -- QUICK DIRTY PATCH FOR THE CAMERA SPAWNING UNDERGROUND FROM THE 0.28 UDPATE
-            local contents = jsonReadFile(getMissionPath() .. "main/MissionGroup/PlayerDropPoints/items.level.json")
 
-            local position = contents["position"] or { 0, 0, 0 }
-
-            position[3] = position[3] + 2 -- otherwise the cam spawns in the ground
-
-            -- local rotation = contents["rotationMatrix"] -- the info in this table can be borked, so we use 0 for all rotations
-            core_camera.setPosRot(0, position[1], position[2], position[3], 0, 0, 0, 0)
+			if not DefaultSpawnFunc() then
+				NewSpawnFunc()
+			end
 		end
 	end
 end


### PR DESCRIPTION
Spawns camera using default spawn points and fixes `onWorldReadyState()` error on "Italy" and other maps which are missing "PlayerDropPoints" 

- Improved version will attempt to find a random spawn point from a pre-selected list of potential spawn groups (including "spawnpoints" for "Italy") and if not found will use alternate default spawn point.