### PR TITLE
Fixes the Fadeout Close Vehicles Option

### DIFF
--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1747,9 +1747,9 @@ local function onPreRender(dt)
 					dist = string.format(" %s %s", tostring(mapEntry), unit)
 				end
 
-				if settings.getValue("fadeVehicles") then
+				if settings.getValue("fadeVehicles") and veh then
 					if activeVehID == gameVehicleID then veh:setMeshAlpha(1, "", false)
-					else veh:setMeshAlpha(1-nametagAlpha, "", false) end
+					else veh:setMeshAlpha(1 - clamp(linearScale(distfloat, 20, 0, 0, 1), 0, 1), "", false) end
 				end
 
 				if settings.getValue("nameTagFadeEnabled") and not commands.isFreeCamera() then


### PR DESCRIPTION
if that option is tickes then it will cause lots of error logs when the to be faded vehicle doesnt exists yet, because of a missing check.

Additionally the fade out distance was hooked to the same distance that nametags are faded out. Since players can have this setting into the hundreds of meters.. this can cause any vehicle in the players vicinity to not be or barely visible. The fade distance is now hardcoded (until a setting is provided) to 20 Meters.