### PR TITLE
chat early display fix

### DIFF
--- a/lua/ge/extensions/UI.lua
+++ b/lua/ge/extensions/UI.lua
@@ -457,7 +457,7 @@ local function onExtensionLoaded()
 end
 
 local function onUpdate()
-    if not settings.getValue("enableNewChatMenu") or not initialized or not M.canRender or MPCoreNetwork and not MPCoreNetwork.isMPSession() then return end
+    if worldReadyState ~= 2 or not settings.getValue("enableNewChatMenu") or not initialized or not M.canRender or MPCoreNetwork and not MPCoreNetwork.isMPSession() then return end
     renderWindow()
 end
 


### PR DESCRIPTION
prevent chat showing during loading process and only display it once completely loaded into the server and loading screen is over