### PR TITLE
Fixes #388 -> MPGameNetwork attempts to index a function

### DIFF
--- a/lua/ge/extensions/MPCoreNetwork.lua
+++ b/lua/ge/extensions/MPCoreNetwork.lua
@@ -58,7 +58,7 @@ local function send(s)
 	
 	end
 	-- Else we now will use the V2 Networking
-	if not TCPLauncherSocket then return end
+	if TCPLauncherSocket == nop then return end
 
 	local bytes, error, index = TCPLauncherSocket:send(#s..'>'..s)
 	if error then

--- a/lua/ge/extensions/MPGameNetwork.lua
+++ b/lua/ge/extensions/MPGameNetwork.lua
@@ -74,7 +74,7 @@ local function sendData(s)
 	end
 
 	-- Else we now will use the V2 Networking
-	if not TCPLauncherSocket then return end
+	if TCPLauncherSocket == nop then return end
 	local bytes, error, index = TCPLauncherSocket:send(#s..'>'..s)
 	if error then
 		isConnecting = false


### PR DESCRIPTION
Untested. The lua mod introduces "nop" as being the default value for the var TCPLauncherSocket. I have no idea what this is. But this var is either "nop" or a cfunction from the socket lib. And it looks like that the expression _not nop_, is false, which appears to cause this bug https://github.com/BeamMP/BeamMP/issues/388