### PR TITLE
keep text input cursor inside text input field after sending message

### DIFF
--- a/lua/ge/extensions/UI.lua
+++ b/lua/ge/extensions/UI.lua
@@ -61,7 +61,8 @@ M.defaultSettings = {
         inactiveFade = true,
         fadeTime = 2.5,
         fadeWhenCollapsed = false,
-        showOnMessage = true
+        showOnMessage = true,
+        keepActive = true
     }
 }
 

--- a/lua/ge/extensions/multiplayer/ui/chat.lua
+++ b/lua/ge/extensions/multiplayer/ui/chat.lua
@@ -325,13 +325,21 @@ local function render()
         imgui.SetNextItemWidth(imgui.GetWindowWidth() - 25)
         if imgui.InputText("##ChatInputMessage", chatMessageBuf, 256, imgui.InputTextFlags_EnterReturnsTrue + imgui.InputTextFlags_CallbackHistory, inputCallbackC) then
             sendChatMessage(chatMessageBuf)
-            imgui.SetKeyboardFocusHere(-1)
+            if UI.settings.window.keepActive then
+                imgui.SetKeyboardFocusHere(-1)
+            else
+                imgui.SetKeyboardFocusHere(1)
+            end
         end
 
         imgui.SameLine()
         if utils.imageButton(UI.uiIcons.send.texId, 20) then
             sendChatMessage(chatMessageBuf)
-            imgui.SetKeyboardFocusHere(-1)
+            if UI.settings.window.keepActive then
+                imgui.SetKeyboardFocusHere(-1)
+            else
+                imgui.SetKeyboardFocusHere(1)
+            end
         end
 
         imgui.EndChild()

--- a/lua/ge/extensions/multiplayer/ui/chat.lua
+++ b/lua/ge/extensions/multiplayer/ui/chat.lua
@@ -325,13 +325,13 @@ local function render()
         imgui.SetNextItemWidth(imgui.GetWindowWidth() - 25)
         if imgui.InputText("##ChatInputMessage", chatMessageBuf, 256, imgui.InputTextFlags_EnterReturnsTrue + imgui.InputTextFlags_CallbackHistory, inputCallbackC) then
             sendChatMessage(chatMessageBuf)
-            imgui.SetKeyboardFocusHere(1)
+            imgui.SetKeyboardFocusHere(-1)
         end
 
         imgui.SameLine()
         if utils.imageButton(UI.uiIcons.send.texId, 20) then
             sendChatMessage(chatMessageBuf)
-            imgui.SetKeyboardFocusHere(1)
+            imgui.SetKeyboardFocusHere(-1)
         end
 
         imgui.EndChild()

--- a/lua/ge/extensions/multiplayer/ui/options.lua
+++ b/lua/ge/extensions/multiplayer/ui/options.lua
@@ -130,7 +130,7 @@ local function renderGeneral()
             UI.settings.window.showOnMessage = pShowOnMessage[0]
         end
 
-		--Keep active on Enter
+	--Keep active on Enter
         imgui.Text("Keep active on Enter")
         imgui.SameLine()
         imgui.SetCursorPosX(posx)

--- a/lua/ge/extensions/multiplayer/ui/options.lua
+++ b/lua/ge/extensions/multiplayer/ui/options.lua
@@ -130,6 +130,15 @@ local function renderGeneral()
             UI.settings.window.showOnMessage = pShowOnMessage[0]
         end
 
+		--Keep active on Enter
+        imgui.Text("Keep active on Enter")
+        imgui.SameLine()
+        imgui.SetCursorPosX(posx)
+        local pKeepActive = imgui.BoolPtr(UI.settings.window.keepActive)
+        if imgui.Checkbox("##Keep active on Enter", pKeepActive) then
+            UI.settings.window.keepActive = pKeepActive[0]
+        end
+        
         -- Bottom Buttons
         imgui.EndChild()
 


### PR DESCRIPTION
very small change, but this is QoL for sending multiple chat messages without having to use the mouse to refocus