### PR TITLE
Fix unsupported powertrain device handling

### DIFF
--- a/lua/vehicle/extensions/BeamMP/MPInputsVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPInputsVE.lua
@@ -17,6 +17,8 @@ local lastInputs = {
 	c = 0,
 }
 local remoteGear
+local unsupportedPowertrainDevice = false
+local unsupportedPowertrainGearbox = false
 -- ============= VARIABLES =============
 
 local translationTable = {
@@ -41,7 +43,14 @@ local gearBoxHandler = {
 
 local function applyGear(data) --TODO: add handling for mismatched gearbox types between local and remote vehicle
 	if not electrics.values.gearIndex or electrics.values.gear == data then return end
-	local powertrainDevice = powertrain.getDevice("gearbox") or powertrain.getDevice("frontMotor") or powertrain.getDevice("rearMotor") or powertrain.getDevice("mainMotor") or "none"
+	local powertrainDevice = powertrain.getDevice("gearbox") or powertrain.getDevice("frontMotor") or powertrain.getDevice("rearMotor") or powertrain.getDevice("mainMotor")
+	if powertrainDevice == nil then -- mods that introduce custom powertrains can trigger this
+		if not unsupportedPowertrainDevice then
+			unsupportedPowertrainDevice = true -- prevent spamming the log
+			print('MPInputsVE Error in "applyGear()". Unsupported powertrain')
+		end
+		return nil
+	end 
 	
 	-- certain gearbox need to be shifted with setGearIndex() while others need to be shifted with shiftXOnY()
 	if gearBoxHandler[powertrainDevice.type] == 1 then
@@ -65,7 +74,10 @@ local function applyGear(data) --TODO: add handling for mismatched gearbox types
 		end
 		
 	else
-		print('MPInputsVE Error in "applyGear()" unknown GearBoxType "' .. powertrainDevice.type .. '"')
+		if not unsupportedPowertrainGearbox then
+			unsupportedPowertrainGearbox = true -- prevent spamming the log
+			print('MPInputsVE Error in "applyGear()" unknown GearBoxType "' .. powertrainDevice.type .. '"')
+		end
 	end
 end
 


### PR DESCRIPTION
Some mods introduce their own custom powertrain. Some are incompatible to the way beammp shifts a gearbox. Unsupported devices where not handled so far which lead to the vehicle to be deactivated by the game. This pr wont introduce missing powertrains, but rather just prevents the execution of `applyGear()` in `MPInputsVE.lua`