### PR TITLE
Improve the kick dialog (onAuth)

### DIFF
--- a/lua/ge/extensions/MPCoreNetwork.lua
+++ b/lua/ge/extensions/MPCoreNetwork.lua
@@ -532,6 +532,13 @@ local function onUpdate(dt)
 				-- break it up into code + data
 				local code = string.sub(received, 1, 1)
 				local data = string.sub(received, 2)
+
+				if HandleNetwork[code] == nil then
+					TCPLauncherSocket = nop
+					log('E', 'onUpdate', 'Received unknown code: '..code)
+					break
+				end
+
 				HandleNetwork[code](data)
 			end
 		end

--- a/ui/modules/multiplayer/multiplayer.js
+++ b/ui/modules/multiplayer/multiplayer.js
@@ -275,10 +275,17 @@ function($scope, $state, $timeout, $mdDialog) {
 
 	$scope.$on('LoadingInfo', function (event, data) {
 		if (document.getElementById('LoadingStatus').innerText != data.message) console.log(data.message)
+
+		// Escape all html
+		data.message = data.message.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+		
+		// Replace ^p with <br>
+		data.message = data.message.replace(/\^p/g, "<br>");
+
 		if (data.message == "done") {
-			document.getElementById('LoadingStatus').innerText = "Done";
+			document.getElementById('LoadingStatus').innerHTML = "Done";
 		} else {
-			document.getElementById('LoadingStatus').innerText = data.message;
+			document.getElementById('LoadingStatus').innerHTML = data.message;
 		}
 		
 		document.getElementById('OriginalLoadingStatus').setAttribute("hidden", "hidden");


### PR DESCRIPTION
This PR fixes console spam that occurs when you get kicked and also adds support to multiline kick messages using "^p". This character was chosen, because it is also used in the description field of the server list.