### PR TITLE
fixed wrong body been used when simple traffic body doesnt exist

### DIFF
--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -12,6 +12,7 @@
 
 local M = {}
 
+local jbeamIO = require('jbeam/io') -- to be used later for getting slotting information of parts
 
 -- ============= VARIABLES =============
 local lastResetTime = {}
@@ -847,13 +848,14 @@ local function applyVehSpawn(event)
 	nextSpawnIsRemote = true -- this flag is used to indicate whether the next spawn is remote or not
 
 	if settings.getValue("simplifyRemoteVehicles") then
-		local vehicleDir=string.format("/vehicles/%s/",vehicleName)
-		local ioCtx={preloadedDirs={vehicleDir,"/vehicles/common/"}} -- Fake io context
-		local partID=simplified_vehicles[vehicleName]
-		local part=jbeamIO.getPart(ioCtx,partID) -- Returns nil if the partID is nil or if the part with given id doesnt exist
-		local expectedSlotName=vehicleName..'_body'
-		if part and (part.slotType==expectedSlotName or tableContains(part.slotType,expectedSlotName)) then -- THIS CHECK IS NOT SLOTS2 COMPATIBLE
-			vehicleConfig.parts[expectedSlotName]=partID
+		local expectedPartID=simplified_vehicles[vehicleName]
+		if expectedPartID then
+			local ioCtx={preloadedDirs={string.format("/vehicles/%s/",vehicleName),"/vehicles/common/"}} -- Fake io context for jbeamIO
+			local slotMap=jbeamIO.getAvailableSlotMap(ioCtx) -- slots2 compatible, maybe theres better way then require jbeamio and let it load the files again...
+			local expectedSlotName=vehicleName..'_body' -- guess the slot that takes in the simplified body
+			if slotMap and slotMap[expectedSlotName] and tableContains(slotMap[expectedSlotName],expectedPartID) then
+				vehicleConfig.parts[expectedSlotName]=expectedPartID
+			end
 		end
 	end
 
@@ -904,13 +906,14 @@ local function applyVehEdit(serverID, data)
 	if checkIfVehiclenameInvalid(vehicleName, playerName, vehicles[serverID]) then return end
 
 	if settings.getValue("simplifyRemoteVehicles") then
-		local vehicleDir=string.format("/vehicles/%s/",vehicleName)
-		local ioCtx={preloadedDirs={vehicleDir,"/vehicles/common/"}} -- Fake io context
-		local partID=simplified_vehicles[vehicleName]
-		local part=jbeamIO.getPart(ioCtx,partID) -- Returns nil if the partID is nil or if the part with given id doesnt exist
-		local expectedSlotName=vehicleName..'_body'
-		if part and (part.slotType==expectedSlotName or tableContains(part.slotType,expectedSlotName)) then -- THIS CHECK IS NOT SLOTS2 COMPATIBLE
-			vehicleConfig.parts[expectedSlotName]=partID
+		local expectedPartID=simplified_vehicles[vehicleName]
+		if expectedPartID then
+			local ioCtx={preloadedDirs={string.format("/vehicles/%s/",vehicleName),"/vehicles/common/"}} -- Fake io context for jbeamIO
+			local slotMap=jbeamIO.getAvailableSlotMap(ioCtx) -- slots2 compatible, maybe theres better way then require jbeamio and let it load the files again...
+			local expectedSlotName=vehicleName..'_body' -- guess the slot that takes in the simplified body
+			if slotMap and slotMap[expectedSlotName] and tableContains(slotMap[expectedSlotName],expectedPartID) then
+				vehicleConfig.parts[expectedSlotName]=expectedPartID
+			end
 		end
 	end
 

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -65,7 +65,7 @@ local roleToInfo = {
 --- Contains the known simplified Vehicle versions.
 -- JBeamNames are Strings eg. "moonhawk", "unicycle"
 -- @table simplified_vehicles
--- @tfield string JBeamName_1 eg. "simple_traffic_coupe"
+-- @tfield string JBeamName_1 eg. "simple_traffic_body_5door_wagon"
 -- @tfield string JBeamName_N
 -- @usage local simplified = simplified_vehicles["coupe"]
 local simplified_vehicles = {
@@ -77,20 +77,20 @@ local simplified_vehicles = {
 	bolide = "simple_traffic_bolide",
 	burnside = "simple_traffic_burnside",
 	citybus = "simple_traffic_citybus",
-	coupe = "simple_traffic_coupe",
-	covet = "simple_covet",
-	etk800 = "simple_traffic_etk800",
-	etkc = "simple_traffic_etkc",
-	etki = "simple_traffic_etki",
+	coupe = "simple_traffic_body_2door_coupe",
+	covet = "simple_traffic_body_3door_hatch",
+	etk800 = "simple_traffic_body_5door_wagon",
+	etkc = "simple_traffic_body_2door_coupe",
+	etki = "simple_traffic_body_4door_sedan",
 	fullsize = "simple_traffic_fullsize",
 	hopper = "simple_traffic_hopper",
-	lansdale = "simple_traffic_lansdale",
-	legran = "simple_traffic_legran",
-	midsize = "simple_traffic_midsize",
+	lansdale = "simple_traffic_body_5door_wagon",
+	legran = "simple_traffic_body_4door_sedan",
+	midsize = "simple_traffic_body_4door_sedan",
 	midtruck = "simple_traffic_midtruck",
 	miramar = "simple_traffic_miramar",
 	moonhawk = "simple_traffic_moonhawk",
-	pessima = "simple_traffic_pessima",
+	pessima = "simple_traffic_body_4door_sedan",
 	pickup = "simple_traffic_pickup",
 	pigeon = "simple_traffic_pigeon",
 	racetruck = "simple_traffic_racetruck",
@@ -98,11 +98,12 @@ local simplified_vehicles = {
 	rockbouncer = "simple_traffic_rockbouncer",
 	sbr = "simple_traffic_sbr",
 	scintilla = "simple_traffic_scintilla",
-	semi = "simple_traffic_semi",
-	sunburst = "simple_traffic_sunburst",
+	--semi = "simple_traffic_semi",
+	sunburst = "simple_traffic_body_4door_sedan",
+	us_semi = "simple_traffic_us_semi",
 	utv = "simple_traffic_utv",
 	van = "simple_traffic_van",
-	vivace = "simple_vivace_slothub",
+	vivace = "simple_traffic_vivace",
 	wendover = "simple_traffic_wendover",
 	wigeon = "simple_traffic_wigeon"
 }

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -541,6 +541,25 @@ local function localVehiclesExist()
 	return false
 end
 
+--- make sure and get the part slot for simplified body, its part id, for the given vehicles
+-- @tparam string vehicleName, eg covet, midsize
+-- @treturn bool canSimplify does vehicle have simplified body
+-- @treturn string slotName the slot that needs to be changed
+-- @treturn string partName the part that needs to go in
+-- @usage local canSimplify, slotName, partName = vehicleGetSimplified("vivace")
+local function getVehicleSimplified(vehicleName)
+	local expectedPartID = simplified_vehicles[vehicleName]
+	if expectedPartID then
+		local ioCtx = {preloadedDirs = {string.format("/vehicles/%s/", vehicleName), "/vehicles/common/"}} -- Fake io context for jbeamIO
+		local slotMap = jbeamIO.getAvailableSlotMap(ioCtx) -- slots2 compatible, maybe theres better way then require jbeamio and let it load the files again...
+		local expectedSlotName = vehicleName..'_body' -- guess the slot that takes in the simplified body, for now
+		if slotMap and slotMap[expectedSlotName] and tableContains(slotMap[expectedSlotName], expectedPartID) then
+			return true, expectedSlotName, expectedPartID
+		end
+	end
+	return false
+end
+
 -- ============= OBJECTS =============
 local Player = {}
 Player.__index = Player
@@ -848,14 +867,9 @@ local function applyVehSpawn(event)
 	nextSpawnIsRemote = true -- this flag is used to indicate whether the next spawn is remote or not
 
 	if settings.getValue("simplifyRemoteVehicles") then
-		local expectedPartID=simplified_vehicles[vehicleName]
-		if expectedPartID then
-			local ioCtx={preloadedDirs={string.format("/vehicles/%s/",vehicleName),"/vehicles/common/"}} -- Fake io context for jbeamIO
-			local slotMap=jbeamIO.getAvailableSlotMap(ioCtx) -- slots2 compatible, maybe theres better way then require jbeamio and let it load the files again...
-			local expectedSlotName=vehicleName..'_body' -- guess the slot that takes in the simplified body
-			if slotMap and slotMap[expectedSlotName] and tableContains(slotMap[expectedSlotName],expectedPartID) then
-				vehicleConfig.parts[expectedSlotName]=expectedPartID
-			end
+		local canSimplify, slotName, partName = vehicleGetSimplified(vehicleName)
+		if canSimplify then
+			vehicleConfig.parts[slotName] = partName
 		end
 	end
 
@@ -906,14 +920,9 @@ local function applyVehEdit(serverID, data)
 	if checkIfVehiclenameInvalid(vehicleName, playerName, vehicles[serverID]) then return end
 
 	if settings.getValue("simplifyRemoteVehicles") then
-		local expectedPartID=simplified_vehicles[vehicleName]
-		if expectedPartID then
-			local ioCtx={preloadedDirs={string.format("/vehicles/%s/",vehicleName),"/vehicles/common/"}} -- Fake io context for jbeamIO
-			local slotMap=jbeamIO.getAvailableSlotMap(ioCtx) -- slots2 compatible, maybe theres better way then require jbeamio and let it load the files again...
-			local expectedSlotName=vehicleName..'_body' -- guess the slot that takes in the simplified body
-			if slotMap and slotMap[expectedSlotName] and tableContains(slotMap[expectedSlotName],expectedPartID) then
-				vehicleConfig.parts[expectedSlotName]=expectedPartID
-			end
+		local canSimplify, slotName, partName = vehicleGetSimplified(vehicleName)
+		if canSimplify then
+			vehicleConfig.parts[slotName] = partName
 		end
 	end
 

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -895,8 +895,12 @@ local function applyVehEdit(serverID, data)
 
 	if checkIfVehiclenameInvalid(vehicleName, playerName, vehicles[serverID]) then return end
 
-	if settings.getValue("simplifyRemoteVehicles") and simplified_vehicles[vehicleName] then
-		vehicleConfig.parts[vehicleName..'_body'] = simplified_vehicles[vehicleName]
+	if settings.getValue("simplifyRemoteVehicles") then
+		local vehicleDir=string.format("/vehicles/%s/",vehicleName)
+		local ioCtx={preloadedDirs={vehicleDir,"/vehicles/common/"}} -- Fake
+		if jbeamIO.getPart(ioCtx,simplified_vehicles[vehicleName]) then -- Throws nil if the partID is nil or if the partID is not real
+			vehicleConfig.parts[vehicleName..'_body'] = simplified_vehicles[vehicleName]
+		end
 	end
 
 	if vehicleName == veh:getJBeamFilename() then

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -845,8 +845,15 @@ local function applyVehSpawn(event)
 
 	nextSpawnIsRemote = true -- this flag is used to indicate whether the next spawn is remote or not
 
-	if settings.getValue("simplifyRemoteVehicles") and simplified_vehicles[vehicleName] then
-		vehicleConfig.parts[vehicleName..'_body'] = simplified_vehicles[vehicleName]
+	if settings.getValue("simplifyRemoteVehicles") then
+		local vehicleDir=string.format("/vehicles/%s/",vehicleName)
+		local ioCtx={preloadedDirs={vehicleDir,"/vehicles/common/"}} -- Fake io context
+		local partID=simplified_vehicles[vehicleName]
+		local part=jbeamIO.getPart(ioCtx,partID) -- Returns nil if the partID is nil or if the part with given id doesnt exist
+		local expectedSlotName=vehicleName..'_body'
+		if part and (part.slotType==expectedSlotName or tableContains(part.slotType,expectedSlotName)) then -- THIS CHECK IS NOT SLOTS2 COMPATIBLE
+			vehicleConfig.parts[expectedSlotName]=partID
+		end
 	end
 
 	local spawnedVehID = getGameVehicleID(event.serverVehicleID)
@@ -897,9 +904,12 @@ local function applyVehEdit(serverID, data)
 
 	if settings.getValue("simplifyRemoteVehicles") then
 		local vehicleDir=string.format("/vehicles/%s/",vehicleName)
-		local ioCtx={preloadedDirs={vehicleDir,"/vehicles/common/"}} -- Fake
-		if jbeamIO.getPart(ioCtx,simplified_vehicles[vehicleName]) then -- Throws nil if the partID is nil or if the partID is not real
-			vehicleConfig.parts[vehicleName..'_body'] = simplified_vehicles[vehicleName]
+		local ioCtx={preloadedDirs={vehicleDir,"/vehicles/common/"}} -- Fake io context
+		local partID=simplified_vehicles[vehicleName]
+		local part=jbeamIO.getPart(ioCtx,partID) -- Returns nil if the partID is nil or if the part with given id doesnt exist
+		local expectedSlotName=vehicleName..'_body'
+		if part and (part.slotType==expectedSlotName or tableContains(part.slotType,expectedSlotName)) then -- THIS CHECK IS NOT SLOTS2 COMPATIBLE
+			vehicleConfig.parts[expectedSlotName]=partID
 		end
 	end
 


### PR DESCRIPTION
before this, when the simple vehicle option is turned on, and if there is an entry in simplified_vehicles for the vehicle, it will attempt to replace the body slot of said vehicle to the simple traffic body
regardless if the part actually exist:
- instead of the original body, vehicles end up with the default body, if the part doesn't exist or not valid
added bonus:
since the recent beamng update, the naming convention for the simple traffic parts have changed, that means:
- all vehicles, include the one with the simple traffic variant, will have their body changed to default body

i want to fix it so it check if the part exists and the slot matches, and i want to update the list in simplified_vehicles

so far i have done the existence check, but idk how to test it, someone plz tell me beammp deving workflow