### PR TITLE
Update to support non-existent setGearboxMode for B25-Mitchell

### DIFF
--- a/lua/vehicle/extensions/BeamMP/MPElectricsVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPElectricsVE.lua
@@ -469,7 +469,9 @@ local function onReset()
 		electrics.values.absMode = settings.getValue("absBehavior", "realistic")
 	end
 	if v.mpVehicleType == "R" then
-		controller.mainController.setGearboxMode("realistic")
+		if controller.mainController.setGearboxMode then
+			controller.mainController.setGearboxMode("realistic")
+		end
 		if wheels then wheels.setABSBehavior(electrics.values.absMode or "realistic") end
 		localSwingwing = 0
 		remoteignition = true


### PR DESCRIPTION
This PR fixes the fatal error of setGearboxMode not existing when using the B25.