### PR TITLE
Reduce console spam & blurting or non meaningful data

### DIFF
--- a/lua/ge/extensions/MPConfig.lua
+++ b/lua/ge/extensions/MPConfig.lua
@@ -91,7 +91,7 @@ local function onExtensionLoaded()
 		--settings.impl.defaults[k] = { 'local', v }
 		--settings.impl.defaultValues[k] = v
 	end
-	dump(defaultSettings)
+	--dump(defaultSettings)
 	settings.impl.invalidateCache()
 end
 

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -708,7 +708,9 @@ function Vehicle:new(data)
 
 	o.spectators = {}
 
-	log('W', 'Vehicle:new', string.format("Vehicle %s (%s) created! Data:%s", o.serverVehicleString, o.ownerName, dumps(data)))
+	if not settings.getValue("showDebugOutput") then
+		log('W', 'Vehicle:new', string.format("Vehicle %s (%s) created! Data:%s", o.serverVehicleString, o.ownerName, dumps(data)))
+	end
 	return o
 end
 function Vehicle:getOwner()
@@ -1202,7 +1204,9 @@ local function onServerVehicleSpawned(playerRole, playerNickname, serverVehicleI
 			Player:new({name=playerNickname, playerID=playerServerID, role=playerRole})
 	end
 
-	log("I", "onServerVehicleSpawned", "Received a vehicle spawn for player " .. playerNickname .. " with ID " .. serverVehicleID .. ' '..dumpsz(decodedData, 2))
+	if not settings.getValue("showDebugOutput") then
+	  log("I", "onServerVehicleSpawned", "Received a vehicle spawn for player " .. playerNickname .. " with ID " .. serverVehicleID .. ' '..dumpsz(decodedData, 2))
+	end
 
 	if MPConfig.getPlayerServerID() == decodedData.pid then -- If the IDs match it's a local vehicle
 

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -13,6 +13,8 @@ local M = {}
 
 local jbeamIO = require('jbeam/io') -- to be used later for getting slotting information of parts
 
+setmetatable(_G,{}) -- temporarily disable global notifications
+
 -- ============= VARIABLES =============
 local lastResetTime = {}
 local oneSecCounter = 0
@@ -1992,6 +1994,8 @@ local function onSettingsChanged()
 	--	settingsCache[k]  = ColorF(table.unpack(p))
 	--end
 end
+
+detectGlobalWrites() -- reenable global write notifications
 
 -- Functions
 M.onSerialize = onSerialize

--- a/lua/ge/extensions/positionGE.lua
+++ b/lua/ge/extensions/positionGE.lua
@@ -65,8 +65,7 @@ local function sendVehiclePosRot(data, gameVehicleID)
 			for k,v in pairs(decoded.vel) do decoded.vel[k] = v*simspeedReal end
 			for k,v in pairs(decoded.rvel) do decoded.rvel[k] = v*simspeedReal end
 
-			data = jsonEncode(decoded)
-			MPGameNetwork.send('Zp:'..serverVehicleID..":"..data)
+			MPGameNetwork.send('Zp:'..serverVehicleID..":"..jsonEncode(decoded))
 		end
 	end
 end
@@ -86,16 +85,13 @@ local function applyPos(decoded, serverVehicleID)
 
 	decoded.localSimspeed = simspeedFraction
 
-	data = jsonEncode(decoded)
-
-
 	local veh = be:getObjectByID(vehicle.gameVehicleID)
 	if veh then -- vehicle already spawned, send data
 		if veh.mpVehicleType == nil then
 			veh:queueLuaCommand("MPVehicleVE.setVehicleType('R')")
 			veh.mpVehicleType = 'R'
 		end
-		veh:queueLuaCommand("positionVE.setVehiclePosRot('"..data.."')")
+		veh:queueLuaCommand("positionVE.setVehiclePosRot('"..jsonEncode(decoded).."')")
 	end
 	local deltaDt = math.max((decoded.tim or 0) - (vehicle.lastDt or 0), 0.001)
 	vehicle.lastDt = decoded.tim


### PR DESCRIPTION
This PR aims to reduce the volume of data that is written to console and log.
- Default settings is no longer written to console.
- Global functions from MPvehicleGE is now disabled.
- `data` is no longer a global variable in positionGE.
- Moved some logging to be only enabled when debugging is enabled.