### PR TITLE
Vehicle/Object Config Protection

### DIFF
--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1132,8 +1132,8 @@ local core_vehicles_cloneCurrent = core_vehicles.cloneCurrent
 core_vehicles.cloneCurrent = function ()
 	local vehicle = be:getPlayerVehicle(0)
 	if vehicle:getField("protected", 0) == "1" then
-		local title = MPHelpers.translate("ui.multiplayer.configprotection.clone.title", "Vehicle Clone Error")
-		local msg = MPHelpers.translate("ui.multiplayer.configprotection.clone.message", "Sorry, you cannot clone this vehicle.")
+		local title = MPTranslate("ui.multiplayer.configprotection.clone.title", "Vehicle Clone Error")
+		local msg = MPTranslate("ui.multiplayer.configprotection.clone.message", "Sorry, you cannot clone this vehicle.")
 		guihooks.trigger("toastrMsg", {type="error", title=title, msg=msg})
 		return
 	else
@@ -1145,8 +1145,8 @@ local core_vehicle_partmgmt_saveLocal = extensions.core_vehicle_partmgmt.saveLoc
 local function core_vehicle_partmgmt_saveLocal_overwrite(p1)
 	local vehicle = be:getPlayerVehicle(0)
 	if vehicle:getField("protected", 0) == "1" then
-		local title = MPHelpers.translate("ui.multiplayer.configprotection.save.title", "Vehicle Save Error")
-		local msg = MPHelpers.translate("ui.multiplayer.configprotection.save.message", "Sorry, you cannot save this vehicle.")
+		local title = MPTranslate("ui.multiplayer.configprotection.save.title", "Vehicle Save Error")
+		local msg = MPTranslate("ui.multiplayer.configprotection.save.message", "Sorry, you cannot save this vehicle.")
 		guihooks.trigger("toastrMsg", {type="error", title=title, msg=msg})
 		return
 	else

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1152,8 +1152,8 @@ local function core_vehicle_partmgmt_saveLocal_overwrite(p1)
 	else
 		core_vehicle_partmgmt_saveLocal(p1)
 		
-		local util_createThumbnails_startWork = util_createThumbnails.startWork
-		util_createThumbnails.startWork = function (p1)
+		local util_createThumbnails_startWork = extensions.util_createThumbnails.startWork
+		extensions.util_createThumbnails.startWork = function (p1)
 			local vehicle = be:getPlayerVehicle(0)
 			if vehicle:getField("protected", 0) == "1" then
 				return

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1066,7 +1066,13 @@ local function sendVehicleSpawn(gameVehicleID)
 		vehicleTable.pos = {pos.x, pos.y, pos.z} -- Position
 		vehicleTable.rot = {rot.x, rot.y, rot.z, rot.w} -- Rotation
 		vehicleTable.pro = settings.getValue("protectConfigFromClone", false) -- Should the config be protected?
+		if vehicleTable.pro == true then
+			vehicleTable.pro = "1"
+		else
+			vehicleTable.pro = "0"
+		end
 		vehicleTable.ign = settings.getValue("spawnVehicleIgnitionLevel") or 3 -- Ingition state
+
 		-- The vehicle_manager.lua may not contain the correct color values, since v0.31, when we read them from that lua, so we read those from the object itself
 		vehicleTable.vcf.paints = MPHelpers.getColorsFromVehObj(veh)
 
@@ -1100,6 +1106,12 @@ local function sendVehicleEdit(gameVehicleID)
 	vehicleTable.jbm = veh:getJBeamFilename()
 	vehicleTable.vcf = vehicleData.config
 	vehicleTable.pro = settings.getValue("protectConfigFromClone", false) -- Should the config be protected?
+
+	if vehicleTable.pro == true then
+		vehicleTable.pro = "1"
+	else
+		vehicleTable.pro = "0"
+	end
 	vehicleTable.ign = settings.getValue("spawnVehicleIgnitionLevel") or 3 -- Ingition state
 	-- The vehicle_manager.lua may not contain the correct color values, since v0.31, when we read them from that lua, so we read those from the object itself
 	vehicleTable.vcf.paints = MPHelpers.getColorsFromVehObj(veh)
@@ -1119,7 +1131,7 @@ end
 local core_vehicles_cloneCurrent = core_vehicles.cloneCurrent
 core_vehicles.cloneCurrent = function ()
 	local vehicle = be:getPlayerVehicle(0)
-	if vehicle:getField("protected", 0) == 1 then
+	if vehicle:getField("protected", 0) == "1" then
 		guihooks.trigger("toastrMsg", {type="error", title="Vehicle Clone Error", msg="Sorry, you cannot clone this vehicle."})
 		return
 	else
@@ -1130,7 +1142,7 @@ end
 local core_vehicle_partmgmt_saveLocal = extensions.core_vehicle_partmgmt.saveLocal
 extensions.core_vehicle_partmgmt.saveLocal = function (p1)
 	local vehicle = be:getPlayerVehicle(0)
-	if vehicle:getField("protected", 0) == 1 then
+	if vehicle:getField("protected", 0) == "1" then
 		guihooks.trigger("toastrMsg", {type="error", title="Vehicle Clone Error", msg="Sorry, you cannot save this vehicle."})
 		return
 	else
@@ -1139,7 +1151,7 @@ extensions.core_vehicle_partmgmt.saveLocal = function (p1)
 		local util_createThumbnails_startWork = util_createThumbnails.startWork
 		util_createThumbnails.startWork = function (p1)
 			local vehicle = be:getPlayerVehicle(0)
-			if vehicle:getField("protected", 0) == 1 then
+			if vehicle:getField("protected", 0) == "1" then
 				return
 			else
 				util_createThumbnails_startWork(p1)
@@ -1200,16 +1212,12 @@ local function applyVehSpawn(event)
 	if spawnedVeh then -- if a vehicle with this ID was found update the obj
 		log('W', 'applyVehSpawn', "(spawn)Updating vehicle from server "..vehicleName.." with id "..spawnedVehID)
 		spawn.setVehicleObject(spawnedVeh, {model=vehicleName, config=serialize(vehicleConfig), pos=pos, rot=rot, cling=true})
-		if (protected == true or protected == "true" or protected == 1) then
-			spawnedVeh:setField("protected", 0, 1)
-		end
+		spawnedVeh:setField("protected", 0, protected or "0")
 	else
 		log('W', 'applyVehSpawn', "Spawning new vehicle "..vehicleName.." from server")
 		spawnedVeh = spawn.spawnVehicle(vehicleName, serialize(vehicleConfig), pos, rot, { autoEnterVehicle=false, vehicleName="multiplayerVehicle", cling=true})
 		spawnedVehID = spawnedVeh:getID()
-		if (protected == true or protected == "true" or protected == 1) then
-			spawnedVeh:setField("protected", 0, 1)
-		end
+		spawnedVeh:setField("protected", 0, protected or "0")
 		log('W', 'applyVehSpawn', "Spawned new vehicle "..vehicleName.." from server with id "..spawnedVehID)
 
 		if not vehicles[event.serverVehicleID] then
@@ -1243,6 +1251,7 @@ local function applyVehEdit(serverID, data)
 	local decodedData   = jsonDecode(data) -- Decode the data
 	local vehicleName   = decodedData.jbm -- Vehicle name
 	local vehicleConfig = decodedData.vcf -- Vehicle config
+	local protected       = decodedData.pro
 
 	local playerName = players[decodedData.pid] and players[decodedData.pid].name or 'Unknown'
 
@@ -1290,6 +1299,8 @@ local function applyVehEdit(serverID, data)
 		log('I', 'applyVehEdit', "Updating vehicle from server "..vehicleName.." with id "..serverID)
 		spawn.setVehicleObject(veh, options)
 	end
+	
+	veh:setField("protected", 0, protected or "0")
 end
 
 

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1132,7 +1132,9 @@ local core_vehicles_cloneCurrent = core_vehicles.cloneCurrent
 core_vehicles.cloneCurrent = function ()
 	local vehicle = be:getPlayerVehicle(0)
 	if vehicle:getField("protected", 0) == "1" then
-		guihooks.trigger("toastrMsg", {type="error", title="Vehicle Clone Error", msg="Sorry, you cannot clone this vehicle."})
+		local title = MPHelpers.translate("ui.multiplayer.configprotection.clone.title", "Vehicle Clone Error")
+		local msg = MPHelpers.translate("ui.multiplayer.configprotection.clone.message", "Sorry, you cannot clone this vehicle.")
+		guihooks.trigger("toastrMsg", {type="error", title=title, msg=msg})
 		return
 	else
 		core_vehicles_cloneCurrent()
@@ -1143,7 +1145,9 @@ local core_vehicle_partmgmt_saveLocal = extensions.core_vehicle_partmgmt.saveLoc
 local function core_vehicle_partmgmt_saveLocal_overwrite(p1)
 	local vehicle = be:getPlayerVehicle(0)
 	if vehicle:getField("protected", 0) == "1" then
-		guihooks.trigger("toastrMsg", {type="error", title="Vehicle Clone Error", msg="Sorry, you cannot save this vehicle."})
+		local title = MPHelpers.translate("ui.multiplayer.configprotection.save.title", "Vehicle Save Error")
+		local msg = MPHelpers.translate("ui.multiplayer.configprotection.save.message", "Sorry, you cannot save this vehicle.")
+		guihooks.trigger("toastrMsg", {type="error", title=title, msg=msg})
 		return
 	else
 		core_vehicle_partmgmt_saveLocal(p1)

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1140,7 +1140,7 @@ core_vehicles.cloneCurrent = function ()
 end
 
 local core_vehicle_partmgmt_saveLocal = extensions.core_vehicle_partmgmt.saveLocal
-extensions.core_vehicle_partmgmt.saveLocal = function (p1)
+local function core_vehicle_partmgmt_saveLocal_overwrite(p1)
 	local vehicle = be:getPlayerVehicle(0)
 	if vehicle:getField("protected", 0) == "1" then
 		guihooks.trigger("toastrMsg", {type="error", title="Vehicle Clone Error", msg="Sorry, you cannot save this vehicle."})
@@ -1493,6 +1493,7 @@ end
 
 --============================ ON VEHICLE SWITCHED (CLIENT) ============================
 local function onVehicleSwitched(oldGameVehicleID, newGameVehicleID)
+	extensions.core_vehicle_partmgmt.saveLocal = core_vehicle_partmgmt_saveLocal_overwrite
 	if MPCoreNetwork.isMPSession() then
 		log('I', "onVehicleSwitched", "Vehicle switched from "..oldGameVehicleID or "unknown".." to "..newGameVehicleID or "unknown")
 

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1065,6 +1065,7 @@ local function sendVehicleSpawn(gameVehicleID)
 		vehicleTable.vcf = vehicleData.config -- Vehicle Config, contains paint data
 		vehicleTable.pos = {pos.x, pos.y, pos.z} -- Position
 		vehicleTable.rot = {rot.x, rot.y, rot.z, rot.w} -- Rotation
+		vehicleTable.pro = settings.getValue("protectConfigFromClone", false) -- Should the config be protected?
 		vehicleTable.ign = settings.getValue("spawnVehicleIgnitionLevel") or 3 -- Ingition state
 		-- The vehicle_manager.lua may not contain the correct color values, since v0.31, when we read them from that lua, so we read those from the object itself
 		vehicleTable.vcf.paints = MPHelpers.getColorsFromVehObj(veh)
@@ -1098,6 +1099,7 @@ local function sendVehicleEdit(gameVehicleID)
 	vehicleTable.pid = MPConfig.getPlayerServerID()
 	vehicleTable.jbm = veh:getJBeamFilename()
 	vehicleTable.vcf = vehicleData.config
+	vehicleTable.pro = settings.getValue("protectConfigFromClone", false) -- Should the config be protected?
 	vehicleTable.ign = settings.getValue("spawnVehicleIgnitionLevel") or 3 -- Ingition state
 	-- The vehicle_manager.lua may not contain the correct color values, since v0.31, when we read them from that lua, so we read those from the object itself
 	vehicleTable.vcf.paints = MPHelpers.getColorsFromVehObj(veh)
@@ -1110,6 +1112,40 @@ end
 
 local function sendBeamstate(data, gameVehicleID)
 	MPGameNetwork.send('Ot:'..getServerVehicleID(gameVehicleID)..':'..data)
+end
+
+
+-- Patch Game Functions in relation to vehicle configs
+local core_vehicles_cloneCurrent = core_vehicles.cloneCurrent
+core_vehicles.cloneCurrent = function ()
+	local vehicle = be:getPlayerVehicle(0)
+	if vehicle:getField("protected", 0) == 1 then
+		guihooks.trigger("toastrMsg", {type="error", title="Vehicle Clone Error", msg="Sorry, you cannot clone this vehicle."})
+		return
+	else
+		core_vehicles_cloneCurrent()
+	end
+end
+
+local core_vehicle_partmgmt_saveLocal = extensions.core_vehicle_partmgmt.saveLocal
+extensions.core_vehicle_partmgmt.saveLocal = function (p1)
+	local vehicle = be:getPlayerVehicle(0)
+	if vehicle:getField("protected", 0) == 1 then
+		guihooks.trigger("toastrMsg", {type="error", title="Vehicle Clone Error", msg="Sorry, you cannot save this vehicle."})
+		return
+	else
+		core_vehicle_partmgmt_saveLocal(p1)
+		
+		local util_createThumbnails_startWork = util_createThumbnails.startWork
+		util_createThumbnails.startWork = function (p1)
+			local vehicle = be:getPlayerVehicle(0)
+			if vehicle:getField("protected", 0) == 1 then
+				return
+			else
+				util_createThumbnails_startWork(p1)
+			end
+		end
+	end
 end
 
 
@@ -1144,7 +1180,8 @@ local function applyVehSpawn(event)
 	local vehicleConfig  = decodedData.vcf -- Vehicle config, contains paint data
 	local pos            = vec3(decodedData.pos)
 	local rot            = decodedData.rot.w and quat(decodedData.rot) or quat(0,0,0,0) --ensure the rotation data is good
-	local ignitionLevel   = (type(decodedData.ign) == "number") and decodedData.ign or 3
+	local ignitionLevel  = (type(decodedData.ign) == "number") and decodedData.ign or 3
+	local protected      = decodedData.pro -- Config Protected
 
 	log('I', 'applyVehSpawn', "Spawning a vehicle from server with serverVehicleID "..event.serverVehicleID)
 	log('I', 'applyVehSpawn', "It is for "..event.playerNickname)
@@ -1163,10 +1200,16 @@ local function applyVehSpawn(event)
 	if spawnedVeh then -- if a vehicle with this ID was found update the obj
 		log('W', 'applyVehSpawn', "(spawn)Updating vehicle from server "..vehicleName.." with id "..spawnedVehID)
 		spawn.setVehicleObject(spawnedVeh, {model=vehicleName, config=serialize(vehicleConfig), pos=pos, rot=rot, cling=true})
+		if (protected == true or protected == "true" or protected == 1) then
+			spawnedVeh:setField("protected", 0, 1)
+		end
 	else
 		log('W', 'applyVehSpawn', "Spawning new vehicle "..vehicleName.." from server")
 		spawnedVeh = spawn.spawnVehicle(vehicleName, serialize(vehicleConfig), pos, rot, { autoEnterVehicle=false, vehicleName="multiplayerVehicle", cling=true})
 		spawnedVehID = spawnedVeh:getID()
+		if (protected == true or protected == "true" or protected == 1) then
+			spawnedVeh:setField("protected", 0, 1)
+		end
 		log('W', 'applyVehSpawn', "Spawned new vehicle "..vehicleName.." from server with id "..spawnedVehID)
 
 		if not vehicles[event.serverVehicleID] then
@@ -1179,6 +1222,7 @@ local function applyVehSpawn(event)
 		vehicle.gameVehicleID = spawnedVehID
 		vehicle.isSpawned = true
 		vehicle.jbeam = vehicleName
+		vehicle.protected = protected
 		vehiclesMap[spawnedVehID] = event.serverVehicleID
 
 		players[vehicle.ownerID]:addVehicle(vehicle)

--- a/mp_locales/en-US.json
+++ b/mp_locales/en-US.json
@@ -1,6 +1,8 @@
 {
     "ui.playmodes.multiplayer": "Multiplayer",
     "ui.options.multiplayer": "Multiplayer",
+    "ui.options.multiplayer.protectConfigFromClone": "Enable Config Protection from Cloning",
+    "ui.options.multiplayer.protectConfigFromClone.tooltip": "Protect this config from being cloned by other players.",
     "ui.options.multiplayer.enableNewChatMenu": "New chat menu",
     "ui.options.multiplayer.enableNewChatMenu.tooltip": "The new chat menu uses ImGui. It's customisable, sleek and awesome!",
     "ui.options.multiplayer.enablePosSmoother": "Enable vehicle position smoothing",

--- a/mp_locales/en-US.json
+++ b/mp_locales/en-US.json
@@ -150,5 +150,9 @@
     "ui.multiplayer.security.no_return": "Cancel & Return",
     "ui.multiplayer.security.accept_proceed": "Download & Join",
     "ui.multiplayer.security.title": "Server Mods Detected",
-    "ui.multiplayer.security.prompt": "The server you're joining has mods, which are downloaded and installed automatically. These mods can contain code which will run on your PC, and could be malicious. Please make sure you trust the server owner(s) before continuing. If you trust that the mods are not malicious, you can continue at your own risk. BeamMP is not responsible for any content downloaded from this server. This warning can be disabled in the settings."
+    "ui.multiplayer.security.prompt": "The server you're joining has mods, which are downloaded and installed automatically. These mods can contain code which will run on your PC, and could be malicious. Please make sure you trust the server owner(s) before continuing. If you trust that the mods are not malicious, you can continue at your own risk. BeamMP is not responsible for any content downloaded from this server. This warning can be disabled in the settings.",
+    "ui.multiplayer.configprotection.clone.title": "Vehicle Clone Error",
+    "ui.multiplayer.configprotection.clone.message": "Sorry, you cannot clone this vehicle.",
+    "ui.multiplayer.configprotection.save.title": "Vehicle Save Error",
+    "ui.multiplayer.configprotection.save.message": "Sorry, you cannot save this vehicle."
 }

--- a/ui/modules/options/multiplayer.partial.html
+++ b/ui/modules/options/multiplayer.partial.html
@@ -22,6 +22,14 @@
 -->
 
 <md-list-item md-no-ink ng-show="options.data.values.showAdvancedMPOptions">
+  <p><span class="mp-setting-highlight">{{:: 'ui.options.multiplayer.experimental' | translate }}</span> {{:: 'ui.options.multiplayer.protectConfigFromClone' |
+    translate }}</p>
+  <md-tooltip md-direction="right">{{:: 'ui.options.multiplayer.protectConfigFromClone.tooltip' | translate }}
+  </md-tooltip>
+  <md-checkbox ng-model="options.data.values.protectConfigFromClone" ng-change="options.applyState()"></md-checkbox>
+</md-list-item>
+
+<md-list-item md-no-ink ng-show="options.data.values.showAdvancedMPOptions">
   <p><span class="mp-setting-highlight">{{:: 'ui.options.multiplayer.experimental' | translate }}</span> {{:: 'ui.options.multiplayer.disableInstabilityPausing' |
     translate }}</p>
   <md-tooltip md-direction="right">{{:: 'ui.options.multiplayer.disableInstabilityPausing.tooltip' | translate }}


### PR DESCRIPTION
The aim of this PR is to add code to make the saving and cloning of others vehicles harder. 

A user can enable the setting in the options to protect their configs.

From that point all of their vehicles spawned will be labelled as protected and then another user tries to clone or save it an error will be presented and the request denied.

Needs online testing with other players.