### PR TITLE
Fixes Sync of vehicle colors by signaling the vehicle being ready when it actually is ready

### DIFF
--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1291,9 +1291,6 @@ local function onServerVehicleSpawned(playerRole, playerNickname, serverVehicleI
 
 		log("W", "onServerVehicleSpawned", "ID is same as received ID, synced vehicle gameVehicleID: "..gameVehicleID.." with ServerID: "..serverVehicleID)
 
-		-- Hacky Fix - Lets now send the vehicle data again so that other players on the server actually have the paint data for this vehicle.
-		sendVehicleEdit(gameVehicleID)
-
 	elseif vehicles[serverVehicleID] and vehicles[serverVehicleID].remoteVehID == gameVehicleID then
 
 		log("I", "onServerVehicleSpawned", "This ID already exists, syncing vehicles")

--- a/lua/vehicle/extensions/BeamMP/MPVehicleVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPVehicleVE.lua
@@ -73,7 +73,7 @@ end
 
 --M.onExtensionLoaded = function() addKeyEventListener('E') addKeyEventListener('G') end
 
-local function onExtensionLoaded()
+local function initLastStage()
 	obj:queueGameEngineLua("MPVehicleGE.onVehicleReady("..obj:getID()..")")
 end
 
@@ -81,7 +81,7 @@ setmetatable(input.keys, {}) -- disable deprecated warning
 detectGlobalWrites() -- reenable global write notifications
 
 M.updateGFX = updateGFX
-M.onExtensionLoaded    = onExtensionLoaded
+M.initLastStage    = initLastStage
 
 M.setVehicleType       = setVehicleType
 


### PR DESCRIPTION
## Problem
The `onExtensionLoaded` event in vehicle lua is called when this extension is loaded, its not a safe event to assume that when it is called the vehicle is actually ready. Tho BeamMP's code does so interpret it like that and tells BeamMP's GE lua that the vehicle is ready, which then leads to various issues when accessing the vehicle data, eg. the configs applied colors.

## Solution
Dont interpret `onExtensionLoaded` as a vehicle is ready signal, but use the `initLastStage` event. There might be safer events or solutions, but i couldnt find any documentation about the other events.

## Changes
1. Removed the `MPVehicleVE.onExtensionLoaded()` listener.
2. Added `MPVehicleVE.initLastStage()` listener
3. Undid the hacky color sync from this pr https://github.com/BeamMP/BeamMP/pull/525

## Ready for review
Tested with another member of the beammp team. Thanks to trebor8820
> Tested the following
1. Spawning a vanilla config with its default color
2. Spawning a vanilla config with a custom color
3. Cloning another players config
4. Spawning a entire custom config with its custom colors