### PR TITLE
Addresses an untested case from PR#557

### DIFF
--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -794,6 +794,9 @@ local function sendVehicleSpawn(gameVehicleID)
 		vehicleTable.vcf = vehicleData.config -- Vehicle Config, contains paint data
 		vehicleTable.pos = {pos.x, pos.y, pos.z} -- Position
 		vehicleTable.rot = {rot.x, rot.y, rot.z, rot.w} -- Rotation
+		
+		-- The vehicle_manager.lua may not contain the correct color values, since v0.31, when we read them from that lua, so we read those from the object itself
+		vehicleTable.vcf.paints = MPHelpers.getColorsFromVehObj(veh)
 
 		local stringToSend = jsonEncode(vehicleTable) -- Encode table to send it as json string
 		MPGameNetwork.send('Os:0:'..stringToSend) -- Send table that contain all vehicle informations for each vehicle
@@ -824,6 +827,9 @@ local function sendVehicleEdit(gameVehicleID)
 	vehicleTable.pid = MPConfig.getPlayerServerID()
 	vehicleTable.jbm = veh:getJBeamFilename()
 	vehicleTable.vcf = vehicleData.config
+	
+	-- The vehicle_manager.lua may not contain the correct color values, since v0.31, when we read them from that lua, so we read those from the object itself
+	vehicleTable.vcf.paints = MPHelpers.getColorsFromVehObj(veh)
 
 	local stringToSend = jsonEncode(vehicleTable) -- Encode table to send it as json string
 	MPGameNetwork.send('Oc:'..getServerVehicleID(gameVehicleID)..':'..stringToSend) -- Send table that contain all vehicle informations for each vehicle


### PR DESCRIPTION
https://github.com/BeamMP/BeamMP/pull/557

## Problem (Describtion by @StanleyDudek)
1. You spawn any car model with stock config
2. You replace your car to be same model but another CUSTOM config of that vehicle (should also have any custom color, but probably any color even stock)
3. For observers the color becomes something wrong but not always white or anything and not the previous color, it's like it has bad color data and picks something default

Eg.
1. Spawn a default blue pickup truck
2. Replace that pickup truck with another model but custom config, say custom red bx

## Solution (Idea by @StanleyDudek)
Read the color data directly from the vehicle object instead from the vehicle_manager.lua because it maybe not be ready yet when BeamMP reads it.

## Needs testing