### PR TITLE
Addresses an untested case from PR#557, add color picker and traffic color sync

### DIFF
--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1377,6 +1377,36 @@ local function onVehicleResetted(gameVehicleID)
 	end
 end
 
+--============================ ON VEHICLE COLOR CHANGED (CLIENT) ============================
+local function onVehicleColorChanged(gameVehicleID, index, paint)
+    if not MPCoreNetwork.isMPSession() then return end -- do nothing if singleplayer
+    local vehicle = getVehicleByGameID(gameVehicleID) -- get vehicle table for this vehicle
+    if vehicle and vehicle.serverVehicleString and vehicle.isLocal then -- If serverVehicleID not null and player own vehicle
+        local veh = be:getObjectByID(gameVehicleID) -- get vehicle as object
+		local pos = veh:getPosition() -- get position
+		local rot = quat(veh:getRotation()) -- get rotation
+		local vehicleTable = {
+			pos = {
+				x = pos.x,
+				y = pos.y,
+				z = pos.z
+			},
+			rot = {
+				x = rot.x,
+				y = rot.y,
+				z = rot.z,
+				w = rot.w
+			}
+		}
+		local vehicleData  = extensions.core_vehicle_manager.getVehicleData(gameVehicleID) -- get vehicle's data
+		vehicleTable.vcf = vehicleData.config -- put config in our table
+		vehicleTable.vcf.paints = MPHelpers.getColorsFromVehObj(veh) -- get paints
+        vehicleTable.vcf.paints[index] = paint --insert new paint at index as chosen from color picker
+		vehicleTable.pid = MPConfig.getPlayerServerID()
+		vehicleTable.jbm = veh:getJBeamFilename()
+		MPGameNetwork.send('Or:'..vehicle.serverVehicleString..":"..jsonEncode(vehicleTable).."")
+    end
+end
 
 
 -- server events
@@ -1526,14 +1556,24 @@ end
 local function onServerVehicleResetted(serverVehicleID, data)
 	--print("Reset Event Received for a player")
 	local gameVehicleID = getGameVehicleID(serverVehicleID) -- Get game ID
-	if localCounter - (lastResetTime[serverVehicleID] or 0) > 0.2 then
+    local vehicle = getVehicleByGameID(gameVehicleID) -- get vehicle table for this vehicle
+    if vehicle and vehicle.serverVehicleString and not vehicle.isLocal then -- If serverVehicleID not null and not player own vehicle
 		if gameVehicleID then
 			local veh = be:getObjectByID(gameVehicleID) -- Get associated vehicle
 			if veh then
-				local pr = jsonDecode(data) -- Decoded data
-				veh:reset()
-				if pr then
-					veh:setPositionRotation(pr.pos.x, pr.pos.y, pr.pos.z, pr.rot.x, pr.rot.y, pr.rot.z, pr.rot.w) -- Apply position
+				local vehicleData = jsonDecode(data) -- Decoded data
+				if vehicleData then
+					local vehicleConfig = vehicleData.vcf
+					if vehicleConfig then -- if there's config data
+						if vehicleConfig.paints then -- if there's paint data
+							for k, v in pairs(vehicleConfig.paints) do -- apply paints
+								extensions.core_vehicle_manager.liveUpdateVehicleColors(gameVehicleID, veh, k, v)
+							end
+						end
+					else
+						veh:reset()
+						veh:setPositionRotation(vehicleData.pos.x, vehicleData.pos.y, vehicleData.pos.z, vehicleData.rot.x, vehicleData.rot.y, vehicleData.rot.z, vehicleData.rot.w) -- Apply position
+					end
 				else
 					log('E', "onServerVehicleResetted", "Could not parse posrot JSON")
 				end
@@ -1542,7 +1582,6 @@ local function onServerVehicleResetted(serverVehicleID, data)
 			log('E', "onServerVehicleResetted", "gameVehicleID for "..serverVehicleID.." not found")
 		end
 	end
-	lastResetTime[serverVehicleID] = localCounter
 end
 
 local function onServerVehicleCoupled(serverVehicleID, data)
@@ -2217,6 +2256,7 @@ M.onVehicleSpawned         = onVehicleSpawned
 M.onVehicleDestroyed       = onVehicleDestroyed
 M.onVehicleSwitched        = onVehicleSwitched
 M.onVehicleResetted        = onVehicleResetted
+M.onVehicleColorChanged    = onVehicleColorChanged
 M.onPlayerLeft             = onPlayerLeft
 M.onClientPostStartMission = onDisconnect
 M.onUIInitialised          = onUIInitialised


### PR DESCRIPTION
This is a duplicate of https://github.com/BeamMP/BeamMP/pull/559

but it additionally supplies live color syncing via the color picker as well as syncing of traffic vehicles' colors

@OfficialLambdax did the work of adding the string to table splitter and getColorsFromVehObj() to MPHelpers

use of getColorsFromVehObj() within sendVehicleSpawn() sendVehicleEdit() and onVehicleColorChanged() will now allow us to ensure consistent vehicle colors at all times, and would close https://github.com/BeamMP/BeamMP/issues/270 

this PR removes a 0.2 second delay in onServerVehicleResetted()

My justification here is that edits don't have a delay and they're more intrusive.

If you think this would cause an issue let's talk about it.

The only piece after this is that when a player joins after someone has spawned a vehicle and chosen a new color, they will see the old color until the original player chooses a new vehicle, color, does any tuning or part edits, or simply hits the sync button. A server bug / feature requested would created for this.