### PR TITLE
revised input syncing and added support for custom inputs

### DIFF
--- a/lua/vehicle/extensions/BeamMP/MPInputsVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPInputsVE.lua
@@ -83,7 +83,7 @@ local function applyGear(data) --TODO: add handling for mismatched gearbox types
 end
 
 local function getInputs()
-	local inputTableToSend = {}
+	local inputsToSend = {}
 	for inputName, _ in pairs(input.state) do
 		local state = electrics.values[inputName] -- the electric is the most accurate place to get the input value, the state.val is different with different filters and using the smoother states causes wrong inputs in arcade mode
 		if state then
@@ -97,18 +97,13 @@ local function getInputs()
 			end
 			state = math.floor(state * 1000) / 1000
 			if lastInputsTable[inputName] ~= state then
-				inputTableToSend[inputName] = {state = state}
+				inputsToSend[inputName] = {state = state}
 				lastInputsTable[inputName] = state
 			end
 		end
 	end
-	if not tableIsEmpty(inputTableToSend) then
-		inputTableToSend.g = electrics.values.gear -- if there is any input we also send the gear in case a remote vehicle is spawned after it has been put into gear
-		obj:queueGameEngineLua("MPInputsGE.sendInputs(\'"..jsonEncode(inputTableToSend).."\', "..obj:getID()..")") -- Send it to GE lua
-	end
 
 	 -- Old sync, keeping for temporary cross compatibility --
-	local inputsToSend = {}
 	currentInputs = {
 		s = electrics.values.steering_input and math.floor(electrics.values.steering_input * 1000) / 1000,
 		t = electrics.values.throttle and math.floor(electrics.values.throttle * 100) / 100,

--- a/lua/vehicle/extensions/BeamMP/MPInputsVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPInputsVE.lua
@@ -205,8 +205,7 @@ local function onExtensionLoaded()
 				smoother = newTemporalSmoothing(1, 1, nil, 0),
 				currentValue = 0,
 				state = 0,
-				diffrence = 0,
-				disableLocal = false
+				diffrence = 0
 			}
 		end
 	end

--- a/lua/vehicle/extensions/BeamMP/MPInputsVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPInputsVE.lua
@@ -85,7 +85,7 @@ end
 local function getInputs()
 	local inputTableToSend = {}
 	for inputName, _ in pairs(input.state) do
-		local state = electrics.values[inputName] -- the electric is the most accurate place to get the value, the state.val is different with different filters and using the smoother states causes wrong inputs in arcade mode
+		local state = electrics.values[inputName] -- the electric is the most accurate place to get the input value, the state.val is different with different filters and using the smoother states causes wrong inputs in arcade mode
 		if state then
 			if inputName == "steering" then
 				if v.data.input then
@@ -103,7 +103,7 @@ local function getInputs()
 		end
 	end
 	if not tableIsEmpty(inputTableToSend) then
-		inputTableToSend.g = electrics.values.gear -- if there is any input we also send the gear in case a vehicle is spawned after it's been put into gear
+		inputTableToSend.g = electrics.values.gear -- if there is any input we also send the gear in case a remote vehicle is spawned after it has been put into gear
 		obj:queueGameEngineLua("MPInputsGE.sendInputs(\'"..jsonEncode(inputTableToSend).."\', "..obj:getID()..")") -- Send it to GE lua
 	end
 
@@ -126,7 +126,7 @@ local function getInputs()
 	lastInputs = currentInputs
 
 	if tableIsEmpty(inputsToSend) then return end
-	inputsToSend.g = electrics.values.gear -- if there is any input we also send the gear in case a vehicle is spawned after it's been put into gear
+	inputsToSend.g = electrics.values.gear -- if there is any input we also send the gear in case the remote vehicle is spawned after it's been put into gear
 	obj:queueGameEngineLua("MPInputsGE.sendInputs(\'"..jsonEncode(inputsToSend).."\', "..obj:getID()..")") -- Send it to GE lua
 end
 
@@ -164,7 +164,7 @@ local function applyInputs(data)
 	end
 end
 
-local GEtickrate = 15 -- setting this to half inputsTickrate in MPupdatesGE seems to give smooth results, though with a bit higher latency, mathing it jitters a bit
+local GEtickrate = 15 -- setting this to half inputsTickrate in MPupdatesGE seems to give smooth results, though with a bit higher latency, matching it jitters at certian framerates
 local disableGhostInputs = false
 
 local function updateGFX(dt)
@@ -179,7 +179,6 @@ local function updateGFX(dt)
 		if not disableGhostInputs then
 			disableGhostInputs = true
 			for inputName, _ in pairs(input.state) do
-				dump(inputName)
 				input.setAllowedInputSource(inputName, "local", false)
 				input.setAllowedInputSource(inputName, "BeamMP", true)
 			end
@@ -205,7 +204,7 @@ local function onReset()
 end
 
 local function onExtensionLoaded()
-	for inputName, inputData in pairs(input.state) do
+	for inputName, _ in pairs(input.state) do
 		if not inputCache[inputName] then
 			inputCache[inputName] = {
 				smoother = newTemporalSmoothing(1, 1, nil, 0),

--- a/lua/vehicle/extensions/BeamMP/MPInputsVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPInputsVE.lua
@@ -89,7 +89,7 @@ local function getInputs()
 		if state then
 			if inputName == "steering" then
 				if v.data.input then
-					state = -state / v.data.input.steeringWheelLock or 1 -- converts steering wheel degrees to an input value
+					state = -state / (v.data.input.steeringWheelLock or 1) -- converts steering wheel degrees to an input value
 				end
 			end
 			if math.abs(state) < 0.001 then -- prevent super small values to count as updates
@@ -125,8 +125,6 @@ local function getInputs()
 	obj:queueGameEngineLua("MPInputsGE.sendInputs(\'"..jsonEncode(inputsToSend).."\', "..obj:getID()..")") -- Send it to GE lua
 end
 
-local recievedNewData -- for temporary cross compatibility
-
 local function storeTargetValue(inputName,inputState)
 	if not inputCache[inputName] then
 		inputCache[inputName] = {smoother = newTemporalSmoothing(1, 1, nil, 0), currentValue = 0, state = inputState}
@@ -138,6 +136,8 @@ local function storeTargetValue(inputName,inputState)
 	inputCache[inputName].state = inputState
 	inputCache[inputName].diffrence = math.abs(inputState-inputCache[inputName].currentValue) -- storing and using the difference for the smoother makes the input more responsive on big/quick changes
 end
+
+local recievedNewData -- for temporary cross compatibility
 
 local function applyInputs(data)
 	local decodedData = jsonDecode(data)

--- a/lua/vehicle/extensions/BeamMP/MPInputsVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPInputsVE.lua
@@ -5,7 +5,7 @@
 local M = {}
 
 -- ============= VARIABLES =============
-local smoothingRate = 30 -- setting this to half inputsTickrate in MPupdatesGE seems to give smooth results, though with a bit higher latency, matching it jitters at certian framerates
+local smoothingRate = 30 -- lower values makes the inputs more smooth but less responsive
 
 local lastInputs = {
 	s = 0,


### PR DESCRIPTION
pretty much a rewrite of the input syncing code to support custom inputs and to make steering more responsive

changed steering input filter to direct and instead added temporal smoothing to every input, seems a lot more accurate and more responsive than using the pad filter, it does however add a bit of latency to inputs that where already using direct filtering

disabled local inputs on the remote vehicles so ghost controlling is no longer possible

changed gear sync to send the current gear with any input change so if a queue is spawned late it will sync as soon as there is any input