### PR TITLE
fix for VE extensions not loading with some vehicle configs

### DIFF
--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -999,9 +999,6 @@ local function onVehicleSpawned(gameVehicleID)
 		log("I", "onVehicleSpawned", "New Vehicle Spawned "..gameVehicleID)
 		--log('E', 'nextSpawnIsRemote', tostring(nextSpawnIsRemote))
 
-		veh:queueLuaCommand("extensions.addModulePath('lua/vehicle/extensions/BeamMP')") -- Load lua files
-		veh:queueLuaCommand("extensions.loadModulesInDirectory('lua/vehicle/extensions/BeamMP')")
-
 		if not nextSpawnIsRemote then
 			sendVehicleSpawn(gameVehicleID) -- Send it to the server
 			commands.setGameCamera() -- Force switch from freecam to vehicle camera
@@ -1012,9 +1009,6 @@ local function onVehicleSpawned(gameVehicleID)
 	else
 		if vehicle.jbeam ~= newJbeamName then
 			log("I", "onVehicleSpawned", string.format("Vehicle %i updated from %s to %s", gameVehicleID, vehicle.jbeam, newJbeamName))
-
-			veh:queueLuaCommand("extensions.addModulePath('lua/vehicle/extensions/BeamMP')") -- Load lua files
-			veh:queueLuaCommand("extensions.loadModulesInDirectory('lua/vehicle/extensions/BeamMP')")
 
 			if not nextSpawnIsRemote then
 				sendVehicleEdit(gameVehicleID) -- Send it to the server (as an edit)
@@ -1028,6 +1022,8 @@ local function onVehicleSpawned(gameVehicleID)
 			vehiclesToSync[gameVehicleID] = 1.
 		end
 	end
+
+	veh:queueLuaCommand("extensions.loadModulesInDirectory('lua/vehicle/extensions/BeamMP')") -- Load VE lua extensions
 
 	if vehicle then vehicle.jbeam = newJbeamName end
 end


### PR DESCRIPTION
some configs like the Legran derby configs calls onVehicleSpawned twice for some reason, Which is another bug to look at, But this is causing an edge case where the lua thinks it's an edit instead of a spawn which means VE extensions don't get loaded,
I've fixed the extensions not loading by moving the loadModulesInDirectory queue function out of the spawn/edit checks so it runs every time onVehicleSpawned is called,

This does not cause duplicate extensions from my testing so it shouldn't cause any new issues, I tested it by making a local counter count up every frame in a VE file to see if it ever repeated a number after edits or after spamming the load function in the console, it never duplicated a single number

I also removed addModulePath cause it doesn't seem to be needed, If there is a reason it's there then let me know and i will add it back, the game also doesn't use it when loading the powertrain, controller, energyStorage and auto extensions which makes me think it's not necessary