### PR TITLE
Paint checks and reverted onVehicleReady change

### DIFF
--- a/lua/ge/extensions/MPHelpers.lua
+++ b/lua/ge/extensions/MPHelpers.lua
@@ -159,12 +159,21 @@ local function getColorsFromVehObj(veh)
 	local paints = {}
 	paints[1] = translate_metallic(splitStringToTable(veh:getField("metallicPaintData", 0), " ", 1))
 	paints[1].baseColor = splitStringToTable(veh:getField("color", 0), " ", 1)
-	
+	if tableIsEmpty(paints[1].baseColor) then -- making sure baseColor isn't empty causing failed spawn on recieving end
+		paints[1].baseColor = {1,1,1,1}
+	end
+
 	paints[2] = translate_metallic(splitStringToTable(veh:getField("metallicPaintData", 1), " ", 1))
 	paints[2].baseColor = splitStringToTable(veh:getField("colorPalette0", 0), " ", 1)
-	
+	if tableIsEmpty(paints[2].baseColor) then
+		paints[2].baseColor = {1,1,1,1}
+	end
+
 	paints[3] = translate_metallic(splitStringToTable(veh:getField("metallicPaintData", 2), " ", 1))
 	paints[3].baseColor = splitStringToTable(veh:getField("colorPalette1", 0), " ", 1)
+	if tableIsEmpty(paints[3].baseColor) then
+		paints[3].baseColor = {1,1,1,1}
+	end
 	
 	return paints
 end

--- a/lua/vehicle/extensions/BeamMP/MPVehicleVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPVehicleVE.lua
@@ -73,7 +73,7 @@ end
 
 --M.onExtensionLoaded = function() addKeyEventListener('E') addKeyEventListener('G') end
 
-local function initLastStage()
+local function onExtensionLoaded()
 	obj:queueGameEngineLua("MPVehicleGE.onVehicleReady("..obj:getID()..")")
 end
 
@@ -81,7 +81,7 @@ setmetatable(input.keys, {}) -- disable deprecated warning
 detectGlobalWrites() -- reenable global write notifications
 
 M.updateGFX = updateGFX
-M.initLastStage    = initLastStage
+M.onExtensionLoaded    = onExtensionLoaded
 
 M.setVehicleType       = setVehicleType
 


### PR DESCRIPTION
Non color able vehicles like the unicycle snowman and most props caused the spawn packet to have empty baseColor because getField only returned "white", This caused the vehicle to fail to spawn on receiving end, I've just made it check if paint data exists and if not fill it in with basic paint data.

onVehicleReady didn't get called because initLastStage doesn't get called for extensions and is called before the BeamMP extensions are loaded, this caused Key Event Listeners to not get loaded and GE to not set remote vehicles to remote on vehicle edits, I've just reverted it to onExtensionLoaded because our extensions are loaded after the vehicle is ready anyways