### PR TITLE
centred nametags and fixed spectator nametags not being cleared

### DIFF
--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1967,7 +1967,7 @@ local function onPreRender(dt)
 					v.vehicleHeight = veh:getInitialHeight()
 				end
 				local tempPosx,tempPosy,tempPosz = be:getObjectOOBBCenterXYZ(gameVehicleID)
-        		v.position = vec3(tempPosx,tempPosy,tempPosz)
+				v.position = vec3(tempPosx,tempPosy,tempPosz)
 				v.position.z = v.position.z + (v.vehicleHeight * 0.5) + 0.2
 			end
 

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1540,9 +1540,11 @@ local function onServerVehicleRemoved(serverVehicleID)
 			--vehicle:delete()
 		else
 			log('W', "onServerVehicleRemoved", "Failed removing vehicle "..serverVehicleID..", Vehicle can't be found")
+			vehicle:delete()
 		end
 	else
 		log('W', "onServerVehicleRemoved", "Failed removing vehicle "..serverVehicleID..", ID is unknown")
+		vehicle:delete()
 	end
 end
 

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1150,15 +1150,9 @@ local function onVehicleSpawned(gameVehicleID)
 
 	veh:queueLuaCommand("extensions.loadModulesInDirectory('lua/vehicle/extensions/BeamMP')") -- Load VE lua extensions
 
-	if vehicle then 
+	if vehicle then
 		vehicle.jbeam = newJbeamName
-
-		-- update nametag offset
-		local serverVehID = getServerVehicleID(gameVehicleID)
-		if serverVehID then
-			vehicles[serverVehID].nameTagPosOffset = veh:getInitialNodePosition(veh:getRefNodeId()) - veh.initialNodePosBB:getCenter()
-			vehicles[serverVehID].vehicleHeight = veh:getInitialHeight()
-		end
+		vehicle.vehicleHeight = veh:getInitialHeight()
 	end
 
 end
@@ -1969,13 +1963,11 @@ local function onPreRender(dt)
 			local veh = be:getObjectByID(gameVehicleID)
 
 			if v.isSpawned and veh then -- update position if available
-				if not v.nameTagPosOffset then
-					v.nameTagPosOffset = veh:getInitialNodePosition(veh:getRefNodeId()) - veh.initialNodePosBB:getCenter()
+				if not v.vehicleHeight then
 					v.vehicleHeight = veh:getInitialHeight()
 				end
-
-				local rot = quatFromDir(-vec3(veh:getDirectionVector()):normalized(), vec3(veh:getDirectionVectorUp()):normalized())
-				v.position = veh:getPosition() - v.nameTagPosOffset:rotated(rot)
+				local tempPosx,tempPosy,tempPosz = be:getObjectOOBBCenterXYZ(gameVehicleID)
+        		v.position = vec3(tempPosx,tempPosy,tempPosz)
 				v.position.z = v.position.z + (v.vehicleHeight * 0.5) + 0.2
 			end
 

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1150,7 +1150,17 @@ local function onVehicleSpawned(gameVehicleID)
 
 	veh:queueLuaCommand("extensions.loadModulesInDirectory('lua/vehicle/extensions/BeamMP')") -- Load VE lua extensions
 
-	if vehicle then vehicle.jbeam = newJbeamName end
+	if vehicle then 
+		vehicle.jbeam = newJbeamName
+
+		-- update nametag offset
+		local serverVehID = getServerVehicleID(gameVehicleID)
+		if serverVehID then
+			vehicles[serverVehID].nameTagPosOffset = veh:getInitialNodePosition(veh:getRefNodeId()) - veh.initialNodePosBB:getCenter()
+			vehicles[serverVehID].vehicleHeight = veh:getInitialHeight()
+		end
+	end
+
 end
 
 --============================ ON VEHICLE REMOVED (CLIENT) ============================
@@ -1280,6 +1290,19 @@ local function onVehicleDestroyed(gameVehicleID)
 	end
 end
 
+local function sendActiveVehicleID(newVehObj)
+	local newServerVehicleID = newVehObj.serverVehicleString -- Get serverVehicleID of the vehicle the player switched to
+	if not newServerVehicleID then
+		newServerVehicleID = tostring(MPConfig.getPlayerServerID()) .. '-' .. -1 -- if the vehicle doesn't exist we still want to send that it changed to remove the spectator nametag
+	end
+	if newServerVehicleID then
+		local playerID = MPConfig.getPlayerServerID()
+		local s = tostring(playerID) .. ':' .. newServerVehicleID
+
+		MPGameNetwork.send('Om:'.. s)
+	end
+end
+
 --============================ ON VEHICLE SWITCHED (CLIENT) ============================
 local function onVehicleSwitched(oldGameVehicleID, newGameVehicleID)
 	if MPCoreNetwork.isMPSession() then
@@ -1341,13 +1364,7 @@ local function onVehicleSwitched(oldGameVehicleID, newGameVehicleID)
 					log('E', "onVehicleSwitched", "Could not find a suitable vehicle to switch to, exiting current veh")
 				end
 			else
-				local newServerVehicleID = newVehObj.serverVehicleString -- Get serverVehicleID of the vehicle the player switched to
-				if newServerVehicleID then
-					local playerID, serverVehicleID = MPConfig.getPlayerServerID(), newServerVehicleID
-					local s = tostring(playerID) .. ':' .. newServerVehicleID
-
-					MPGameNetwork.send('Om:'.. s)
-				end
+				sendActiveVehicleID(newVehObj)
 			end
 		end
 	end
@@ -1415,6 +1432,10 @@ local function onServerVehicleSpawned(playerRole, playerNickname, serverVehicleI
 		vehiclesMap[gameVehicleID] = serverVehicleID
 
 		players[playerServerID]:addVehicle(vehObject)
+
+		if be:getPlayerVehicleID(0) == gameVehicleID then
+			sendActiveVehicleID(vehObject)
+		end
 
 		log("W", "onServerVehicleSpawned", "ID is same as received ID, synced vehicle gameVehicleID: "..gameVehicleID.." with ServerID: "..serverVehicleID)
 
@@ -1560,12 +1581,13 @@ end
 
 local function onServerCameraSwitched(playerID, serverVehicleID)
 	if not players[playerID] then return end -- TODO: better fix?
-	if not vehicles[serverVehicleID] then return end
 	if players[playerID] and players[playerID].activeVehicleID and vehicles[players[playerID].activeVehicleID] then
 		vehicles[players[playerID].activeVehicleID].spectators[playerID] = nil -- clear prev spectator field
 	end
 
 	players[playerID].activeVehicleID = serverVehicleID
+
+	if not vehicles[serverVehicleID] then return end
 	vehicles[serverVehicleID].spectators[playerID] = true
 end
 
@@ -1945,7 +1967,14 @@ local function onPreRender(dt)
 			local veh = be:getObjectByID(gameVehicleID)
 
 			if v.isSpawned and veh then -- update position if available
-				v.position = veh:getPosition()
+				if not v.nameTagPosOffset then
+					v.nameTagPosOffset = veh:getInitialNodePosition(veh:getRefNodeId()) - veh.initialNodePosBB:getCenter()
+					v.vehicleHeight = veh:getInitialHeight()
+				end
+
+				local rot = quatFromDir(-vec3(veh:getDirectionVector()):normalized(), vec3(veh:getDirectionVectorUp()):normalized())
+				v.position = veh:getPosition() - v.nameTagPosOffset:rotated(rot)
+				v.position.z = v.position.z + (v.vehicleHeight * 0.5) + 0.2
 			end
 
 			if not v.position then goto skip_vehicle end -- return if no position has been received yet
@@ -1972,6 +2001,7 @@ local function onPreRender(dt)
 
 				if colors then
 					debugDrawer:drawSphere(pos, 1, ColorF(colors[1], colors[2], colors[3], 0.5))
+					pos.z = pos.z + 1
 				end
 			end
 
@@ -2050,7 +2080,6 @@ local function onPreRender(dt)
 				for source, tag in pairs(owner.nickSuffixes)
 					do suffix = suffix..tag.." " end
 
-				pos.z = pos.z + 2.0 -- Offset nametag so it appears above the vehicle, not inside
 
 				-- draw spectators
 				if settings.getValue("showSpectators") then


### PR DESCRIPTION
Currently the name tags are placed 2 meters above the ref node for every vehicle, Here I've moved them to the center of the vehicle 20 cm above the top of the bounding box.
#
Before
![screenshot_2024-07-04_22-16-35](https://github.com/BeamMP/BeamMP/assets/10835721/2171fdbe-0351-4735-a9e3-ae225871a656)
After
![screenshot_2024-07-04_22-15-21](https://github.com/BeamMP/BeamMP/assets/10835721/25bb043e-f7e4-43ec-a140-97292251d2b4)
#
I've also fixed the bug where spectator tags would stay if you cloned or spawned a car while being tabbed to someone else, this happened because the onVehicleSwitched function runs before the vehicle exists in the vehicle map, to fix this i moved the code that sends the active vehicle into it's own function, And then call it when the car is added to the vehicle map if you are tabbed to it.