### PR TITLE
ignition sync rewrite

### DIFF
--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -925,7 +925,7 @@ local function sendVehicleSpawn(gameVehicleID)
 		vehicleTable.vcf = vehicleData.config -- Vehicle Config, contains paint data
 		vehicleTable.pos = {pos.x, pos.y, pos.z} -- Position
 		vehicleTable.rot = {rot.x, rot.y, rot.z, rot.w} -- Rotation
-		
+		vehicleTable.ign = settings.getValue("spawnVehicleIgnitionLevel") or 3 -- Ingition state
 		-- The vehicle_manager.lua may not contain the correct color values, since v0.31, when we read them from that lua, so we read those from the object itself
 		vehicleTable.vcf.paints = MPHelpers.getColorsFromVehObj(veh)
 
@@ -958,7 +958,7 @@ local function sendVehicleEdit(gameVehicleID)
 	vehicleTable.pid = MPConfig.getPlayerServerID()
 	vehicleTable.jbm = veh:getJBeamFilename()
 	vehicleTable.vcf = vehicleData.config
-	
+	vehicleTable.ign = settings.getValue("spawnVehicleIgnitionLevel") or 3 -- Ingition state
 	-- The vehicle_manager.lua may not contain the correct color values, since v0.31, when we read them from that lua, so we read those from the object itself
 	vehicleTable.vcf.paints = MPHelpers.getColorsFromVehObj(veh)
 
@@ -1004,6 +1004,7 @@ local function applyVehSpawn(event)
 	local vehicleConfig   = decodedData.vcf -- Vehicle config, contains paint data
 	local pos             = vec3(decodedData.pos)
 	local rot             = decodedData.rot.w and quat(decodedData.rot) or quat(0,0,0,0) --ensure the rotation data is good
+	local ignitionLevel	  = decodedData.ign or 3
 
 	log('I', 'applyVehSpawn', "Spawning a vehicle from server with serverVehicleID "..event.serverVehicleID)
 	log('I', 'applyVehSpawn', "It is for "..event.playerNickname)
@@ -1045,6 +1046,7 @@ local function applyVehSpawn(event)
 
 	core_vehicles.setPlateText(event.playerNickname, spawnedVehID)
 	spawnedVeh:queueLuaCommand("hydros.onFFBConfigChanged(nil)")
+	spawnedVeh:queueLuaCommand("MPPowertrainVE.setIgnitionState("..ignitionLevel..")")
 end
 
 local function applyVehEdit(serverID, data)

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1004,7 +1004,7 @@ local function applyVehSpawn(event)
 	local vehicleConfig   = decodedData.vcf -- Vehicle config, contains paint data
 	local pos             = vec3(decodedData.pos)
 	local rot             = decodedData.rot.w and quat(decodedData.rot) or quat(0,0,0,0) --ensure the rotation data is good
-	local ignitionLevel	  = decodedData.ign or 3
+	local ignitionLevel   = decodedData.ign or 3
 
 	log('I', 'applyVehSpawn', "Spawning a vehicle from server with serverVehicleID "..event.serverVehicleID)
 	log('I', 'applyVehSpawn', "It is for "..event.playerNickname)

--- a/lua/vehicle/extensions/BeamMP/MPElectricsVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPElectricsVE.lua
@@ -214,6 +214,9 @@ local disallowedKeys = {
 	["accXSmooth"] = 1,
 	["accYSmooth"] = 1,
 	["accZSmooth"] = 1,
+	["engineRunning"] = 1, -- engine and ignition is synced in MPPowertrainVE
+	["ignition"] = 1,
+	["ignitionLevel"] = 1,
 	---modded vehicles --
 	-- me262 plane ------
 	["inst_pitch"] = 1,
@@ -351,35 +354,6 @@ local function applyElectrics(data)
 		-- LineLock syncing
 		if decodedData.linelock and electrics.values.linelock ~= decodedData.linelock then
 			controller.getControllerSafe("lineLock").setLineLock(decodedData.linelock)
-		end
-
-		-- Ignition syncing
-		if decodedData.ignition ~= nil then
-			remoteignition = decodedData.ignition
-		end
-		if decodedData.engineRunning then
-			remoteengineRunning = decodedData.engineRunning
-		end
-		if electrics.values.ignition ~= (remoteignition and 1 or 0) or electrics.values.engineRunning ~= remoteengineRunning then
-			local engine = powertrain.getDevice("mainEngine")
-			if engine then
-				if remoteengineRunning ~= electrics.values.engineRunning then
-					if remoteengineRunning == 1 then
-						if engine.starterEngagedCoef == 0 then
-							engine:activateStarter()
-						end
-					elseif remoteengineRunning == 0 and engine.starterEngagedCoef == 0 then
-						engine:deactivateStarter()
-						engine:cutIgnition(1)
-					end
-				end
-				if electrics.values.ignition ~= (remoteignition and 1 or 0) then
-					controller.mainController.setEngineIgnition(remoteignition)
-				end
-				if not remoteignition and remoteengineRunning == 0 then
-					engine:deactivateStarter()
-				end
-			end
 		end
 
 		-- Unicycle syncing

--- a/lua/vehicle/extensions/BeamMP/MPPowertrainVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPPowertrainVE.lua
@@ -109,17 +109,17 @@ local function applyEngineData(data)
 	end
 	if data.ICE then
 		for engineName,engineData in pairs(data.ICE) do
-			local recievedEngineData = cachedCombustionEngineData[engineName] or {}
+			local receivedEngineData = cachedCombustionEngineData[engineName] or {}
 			if engineData.ign ~= nil then
-				recievedEngineData.ignitionCoef = engineData.ign
+				receivedEngineData.ignitionCoef = engineData.ign
 			end
 			if engineData.starter ~= nil then
-				recievedEngineData.starterEngagedCoef = engineData.starter
+				receivedEngineData.starterEngagedCoef = engineData.starter
 			end
 			if engineData.isStalled ~= nil then
-				recievedEngineData.isStalled = engineData.isStalled
+				receivedEngineData.isStalled = engineData.isStalled
 			end
-			cachedCombustionEngineData[engineName] = recievedEngineData
+			cachedCombustionEngineData[engineName] = receivedEngineData
 		end
 	end
 end
@@ -168,11 +168,11 @@ local function cacheEngines()
 	if next(combustionEngines) then
 		for engineName,engine in pairs(combustionEngines) do
 			engine.spawnVehicleIgnitionLevel = spawnVehicleIgnitionLevel or engine.spawnVehicleIgnitionLevel
-			local recievedEngineData = cachedCombustionEngineData[engineName] or {}
-			recievedEngineData.ignitionCoef = 1
-			recievedEngineData.isStalled = false
-			recievedEngineData.starterEngagedCoef = engine.starterEngagedCoef
-			cachedCombustionEngineData[engine.name] = recievedEngineData
+			local receivedEngineData = cachedCombustionEngineData[engineName] or {}
+			receivedEngineData.ignitionCoef = 1
+			receivedEngineData.isStalled = false
+			receivedEngineData.starterEngagedCoef = engine.starterEngagedCoef
+			cachedCombustionEngineData[engine.name] = receivedEngineData
 		end
 	end
 end

--- a/lua/vehicle/extensions/BeamMP/MPPowertrainVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPPowertrainVE.lua
@@ -167,18 +167,10 @@ local function cacheEngines()
 	local combustionEngines = powertrain.getDevicesByType("combustionEngine")
 	if next(combustionEngines) then
 		for engineName,engine in pairs(combustionEngines) do
-			local recievedEngineData = cachedCombustionEngineData[engineName] or {}
-			if ignitionLevel then
-				if ignitionLevel > 1 then
-					recievedEngineData.ignitionCoef = 1
-				else
-					recievedEngineData.ignitionCoef = 0
-				end
-			else
-				recievedEngineData.ignitionCoef = engine.ignitionCoef
-			end
 			engine.spawnVehicleIgnitionLevel = spawnVehicleIgnitionLevel or engine.spawnVehicleIgnitionLevel
-			recievedEngineData.isStalled = engine.isStalled
+			local recievedEngineData = cachedCombustionEngineData[engineName] or {}
+			recievedEngineData.ignitionCoef = 1
+			recievedEngineData.isStalled = false
 			recievedEngineData.starterEngagedCoef = engine.starterEngagedCoef
 			cachedCombustionEngineData[engine.name] = recievedEngineData
 		end
@@ -187,11 +179,6 @@ end
 
 local function setIgnitionState(remoteignitionLevel)
 	spawnVehicleIgnitionLevel = remoteignitionLevel
-	if remoteignitionLevel > 0 then
-		ignitionLevel = 2
-	else
-		ignitionLevel = 0
-	end
 	cacheEngines()
 end
 

--- a/lua/vehicle/extensions/BeamMP/MPPowertrainVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPPowertrainVE.lua
@@ -8,6 +8,11 @@ local M = {}
 
 -- ============= VARIABLES =============
 local lastDevices = {}
+local lastCombustionEngineData = {}
+local cachedCombustionEngineData = {}
+local ignitionLevel
+local lastignitionLevel
+local spawnVehicleIgnitionLevel
 -- ============= VARIABLES =============
 
 
@@ -51,53 +56,148 @@ local function check()
 end
 
 
-
-local function getEngineData() --TODO add difference check and auto apply on recieving end
-	local data = {}
-	data["ignLvl"] = electrics.values.ignitionLevel
-
+local function getCombustionEngineData(data)
 	local combustionEngines = powertrain.getDevicesByType("combustionEngine")
 	if next(combustionEngines) then
-		data["combustionEngines"] = {}
-		for k,v in pairs(powertrain.getDevicesByType("combustionEngine")) do
-			data["combustionEngines"][v.name] = {
-				ign = v.ignitionCoef,
-				isStalled = v.isStalled
-			}
-			if v.starterEngagedCoef == 1 then
-				data["combustionEngines"][v.name].starter = v.starterEngagedCoef
+		local engines = {}
+		for engineName,engine in pairs(combustionEngines) do
+			local lastEngineData = lastCombustionEngineData[engineName] or {}
+			local engineData = {}
+			if lastEngineData.ignitionCoef ~= engine.ignitionCoef or lastEngineData.isStalled ~= engine.isStalled then
+				engineData.ign = engine.ignitionCoef
+				engineData.isStalled = engine.isStalled
+			end
+			if lastEngineData.starterEngagedCoef ~= engine.starterEngagedCoef then
+				engineData.starter = engine.starterEngagedCoef
+			end
+
+			lastEngineData.ignitionCoef = engine.ignitionCoef
+			lastEngineData.isStalled = engine.isStalled
+			lastEngineData.starterEngagedCoef = engine.starterEngagedCoef
+
+			lastCombustionEngineData[engineName] = lastEngineData
+			if next(engineData) then
+				engines[engine.name] = engineData
 			end
 		end
+		if next(engines) then
+			data.ICE = engines
+		end
 	end
-
-	obj:queueGameEngineLua("MPPowertrainGE.sendEngineData(\'"..jsonEncode(data).."\', "..obj:getID()..")")
+	return data
 end
 
 
+local function getEngineData() --TODO maybe hook the functions instead of checking with ticking
+	local data = {}
+	if electrics.values.ignitionLevel ~= lastignitionLevel then
+		data["ignLvl"] = electrics.values.ignitionLevel
+	end
+	lastignitionLevel = electrics.values.ignitionLevel
+
+	data = getCombustionEngineData(data)
+
+	if next(data) then
+		obj:queueGameEngineLua("MPPowertrainGE.sendEngineData(\'"..jsonEncode(data).."\', "..obj:getID()..")")
+	end
+end
 
 local function applyEngineData(data)
 	data = jsonDecode(data)
 	if data.ignLvl then
-		if electrics.values.ignitionLevel ~= data.ignitionLevel then
-			electrics.setIgnitionLevel(data.ignitionLevel)
+		ignitionLevel = data.ignLvl
+	end
+	if data.ICE then
+		for engineName,engineData in pairs(data.ICE) do
+			local recievedEngineData = cachedCombustionEngineData[engineName] or {}
+			if engineData.ign ~= nil then
+				recievedEngineData.ignitionCoef = engineData.ign
+			end
+			if engineData.starter ~= nil then
+				recievedEngineData.starterEngagedCoef = engineData.starter
+			end
+			if engineData.isStalled ~= nil then
+				recievedEngineData.isStalled = engineData.isStalled
+			end
+			cachedCombustionEngineData[engineName] = recievedEngineData
 		end
 	end
-	if data.combustionEngines then
-		for engineName,engineData in pairs(data.combustionEngines) do
+end
+
+local periodicSynctime = 0
+
+local function updateGFX(dt)
+	if v.mpVehicleType == "R" then
+		if ignitionLevel and electrics.values.ignitionLevel ~= ignitionLevel then
+			electrics.setIgnitionLevel(ignitionLevel)
+		end
+		for engineName,engineData in pairs(cachedCombustionEngineData) do
 			local engine = powertrain.getDevice(engineName)
 			if engine then
-				if engineData.ign then
-					engine:setIgnition(engineData.ign)
+				if engineData.ignitionCoef ~= engine.ignitionCoef then
+					engine:setIgnition(engineData.ignitionCoef)
 				end
-				if engineData.starter or not engineData.isStalled and engine.isStalled and engineData.ign then
-					engine:activateStarter()
+				if engine.starterEngagedCoef == 0 then
+					if engineData.starterEngagedCoef == 1 or not engineData.isStalled and engine.isStalled and engineData.ignitionCoef then
+						engine:activateStarter()
+					end
 				end
+				if engineData.isStalled and not engine.isStalled then
+					engine:cutIgnition(1)
+					if engine.starterEngagedCoef == 1 then
+						engine:deactivateStarter()
+					end
+				end
+			end
+		end
+	else
+		periodicSynctime = periodicSynctime + dt
+		if periodicSynctime >= 10 then
+			periodicSynctime = 0
+			lastignitionLevel = nil
+			for _ , engineData in pairs(lastCombustionEngineData) do
+				engineData.ignitionCoef = nil
+				engineData.isStalled = nil
 			end
 		end
 	end
 end
 
+local function cacheEngines()
+	local combustionEngines = powertrain.getDevicesByType("combustionEngine")
+	if next(combustionEngines) then
+		for engineName,engine in pairs(combustionEngines) do
+			local recievedEngineData = cachedCombustionEngineData[engineName] or {}
+			if ignitionLevel then
+				if ignitionLevel > 1 then
+					recievedEngineData.ignitionCoef = 1
+				else
+					recievedEngineData.ignitionCoef = 0
+				end
+			else
+				recievedEngineData.ignitionCoef = engine.ignitionCoef
+			end
+			engine.spawnVehicleIgnitionLevel = spawnVehicleIgnitionLevel or engine.spawnVehicleIgnitionLevel
+			recievedEngineData.isStalled = engine.isStalled
+			recievedEngineData.starterEngagedCoef = engine.starterEngagedCoef
+			cachedCombustionEngineData[engine.name] = recievedEngineData
+		end
+	end
+end
 
+local function setIgnitionState(remoteignitionLevel)
+	spawnVehicleIgnitionLevel = remoteignitionLevel
+	if remoteignitionLevel > 0 then
+		ignitionLevel = 2
+	else
+		ignitionLevel = 0
+	end
+	cacheEngines()
+end
+
+local function onReset()
+	cacheEngines()
+end
 
 M.check				  = check
 M.check				  = getEngineData
@@ -105,6 +205,10 @@ M.applyLivePowertrain = applyLivePowertrain
 
 M.getEngineData = getEngineData
 M.applyEngineData = applyEngineData
+M.setIgnitionState = setIgnitionState
+M.updateGFX = updateGFX
+M.onExtensionLoaded = onReset
+M.onReset = onReset
 
 
 

--- a/lua/vehicle/extensions/BeamMP/MPPowertrainVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPPowertrainVE.lua
@@ -182,7 +182,7 @@ local function setIgnitionState(remoteignitionLevel)
 	cacheEngines()
 end
 
-local function onReset()
+local function onExtensionLoaded()
 	cacheEngines()
 end
 
@@ -194,8 +194,7 @@ M.getEngineData = getEngineData
 M.applyEngineData = applyEngineData
 M.setIgnitionState = setIgnitionState
 M.updateGFX = updateGFX
-M.onExtensionLoaded = onReset
-M.onReset = onReset
+M.onExtensionLoaded = onExtensionLoaded
 
 
 


### PR DESCRIPTION
now syncs the ignition of all combustion engines individually, this fixes the B25 Mitchell engines not syncing

I've also added the spawnVehicleIgnitionLevel to the spawn packet so we can correctly sync the engine on resets, vehicles will still spawn running by default so we don't have cars driving around without the engine running

the engine and ignition state will now sync periodically so if the state is wrong when the car is spawned it will re-sync after a maximum of 10 seconds

i haven't synced the electric motors individually, However they seem to just automatically sync from just the ignition level sync, though i may add this later in case some mods control multiple motors individually