### PR TITLE
Highlight queued players and selective queuing

### DIFF
--- a/lua/ge/extensions/MPConfig.lua
+++ b/lua/ge/extensions/MPConfig.lua
@@ -62,7 +62,7 @@ end
 local defaultSettings = {
 	autoSyncVehicles = true, nameTagShowDistance = true, enableBlobs = true, showSpectators = true, nametagCharLimit = 32, showPlayerIDs = false,
 	-- queue system
-	enableSpawnQueue = true, enableQueueAuto = true, queueSkipUnicycle = true, queueApplySpeed = 2, queueApplyTimeout = 3,
+	enableSpawnQueue = true, enableQueueAuto = true, queueSkipUnicycle = true, queueApplySpeed = 2, queueApplyTimeout = 3, highlightQueuedPlayers = true,
 	-- colors
 	showBlobQueued = true, blobColorQueued = "#FF6400", showBlobIllegal = true, blobColorIllegal = "#000000", showBlobDeleted = true, blobColorDeleted = "#333333",
 

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1861,20 +1861,22 @@ local function focusCameraOnPlayer(targetName)
 	end
 end
 
-local function applyQueuedEvents()
-	UI.updateQueue(getQueueCounts())
+local function applyVehicleQueues(serverVehicleID, vehicle) 
+	if vehicle.spawnQueue then
+		local data = vehicle.spawnQueue
+		vehicle.spawnQueue = nil
+		applyVehSpawn(data)
+	end
+	if vehicle.editQueue then
+		local data = vehicle.editQueue
+		vehicle.editQueue = nil
+		applyVehEdit(serverVehicleID, data)
+	end
+end
 
+local function applyQueuedEvents()
 	for serverVehicleID, vehicle in pairs(vehicles) do
-		if vehicle.spawnQueue then
-			local data = vehicle.spawnQueue
-			vehicle.spawnQueue = nil
-			applyVehSpawn(data)
-		end
-		if vehicle.editQueue then
-			local data = vehicle.editQueue
-			vehicle.editQueue = nil
-			applyVehEdit(serverVehicleID, data)
-		end
+		applyVehicleQueues(serverVehicleID, vehicle)
 	end
 
 	UI.updateQueue(getQueueCounts())
@@ -1882,20 +1884,9 @@ local function applyQueuedEvents()
 end
 
 local function applyPlayerQueues(playerID)
-	UI.updateQueue(getQueueCounts())
-	
 	for serverVehicleID, vehicle in pairs(vehicles) do
 		if vehicle.ownerID == playerID then
-			if vehicle.spawnQueue then
-				local data = vehicle.spawnQueue
-				vehicle.spawnQueue = nil
-				applyVehSpawn(data)
-			end
-			if vehicle.editQueue then
-				local data = vehicle.editQueue
-				vehicle.editQueue = nil
-				applyVehEdit(serverVehicleID, data)
-			end 
+			applyVehicleQueues(serverVehicleID, vehicle)
 		end
 	end
 

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -905,13 +905,13 @@ local function getQueueCounts()
 		if vehicle.spawnQueue then 
 			spawns = spawns + 1 
 			if highlightQueuedPlayers then
-				table.insert(queuedPlayers, vehicle.ownerID)
+				queuedPlayers[vehicle.ownerID] = true
 			end
 		end
 		if vehicle.editQueue then 
 			edits = edits + 1 
 			if highlightQueuedPlayers then
-				table.insert(queuedPlayers, vehicle.ownerID)
+				queuedPlayers[vehicle.ownerID] = true
 			end
 		end
 	end

--- a/lua/ge/extensions/UI.lua
+++ b/lua/ge/extensions/UI.lua
@@ -153,10 +153,24 @@ end
 --- This function is used to update the edit/spawn queue values for the UI indicator.
 -- @param spawnCount number
 -- @param editCount number
-local function updateQueue( spawnCount, editCount)
+-- @param queuedPlayers table
+local function updateQueue( spawnCount, editCount, queuedPlayers)
 	UIqueue = {spawnCount = spawnCount, editCount = editCount}
 	UIqueue.show = spawnCount+editCount > 0
 	sendQueue()
+
+    
+    if queuedPlayers ~= nil and queuedPlayers ~= {} then 
+        for key, player in pairs(MPVehicleGE.getPlayers()) do
+            if tableContains(queuedPlayers, key) then
+                guihooks.trigger("setQueueState", {playerID = key, state = true})
+            else
+                guihooks.trigger("setQueueState", {playerID = key, state = false})
+            end
+        end
+    else 
+        guihooks.trigger("resetQueueState")
+    end
 end
 
 --- Used to set our ping in the top status bar. It also is used in the math for position prediction

--- a/lua/ge/extensions/UI.lua
+++ b/lua/ge/extensions/UI.lua
@@ -155,14 +155,14 @@ end
 -- @param editCount number
 -- @param queuedPlayers table
 local function updateQueue( spawnCount, editCount, queuedPlayers)
-    if (queuedPlayers ~= nil and queuedPlayers ~= {}) then
+    if (queuedPlayers ~= nil and next(queuedPlayers) ~= nil) then
         for key, player in pairs(MPVehicleGE.getPlayers()) do 
             if queuedPlayers[key] == nil then 
                 queuedPlayers[key] = false
             end
         end
-    else 
-        guihooks.trigger("resetQueueState")
+    else
+        queuedPlayers = nil
     end
 
 	UIqueue = {spawnCount = spawnCount, editCount = editCount, queuedPlayers = queuedPlayers}

--- a/lua/ge/extensions/UI.lua
+++ b/lua/ge/extensions/UI.lua
@@ -155,22 +155,19 @@ end
 -- @param editCount number
 -- @param queuedPlayers table
 local function updateQueue( spawnCount, editCount, queuedPlayers)
-	UIqueue = {spawnCount = spawnCount, editCount = editCount}
-	UIqueue.show = spawnCount+editCount > 0
-	sendQueue()
-
-    
-    if queuedPlayers ~= nil and queuedPlayers ~= {} then 
-        for key, player in pairs(MPVehicleGE.getPlayers()) do
-            if tableContains(queuedPlayers, key) then
-                guihooks.trigger("setQueueState", {playerID = key, state = true})
-            else
-                guihooks.trigger("setQueueState", {playerID = key, state = false})
+    if (queuedPlayers ~= nil and queuedPlayers ~= {}) then
+        for key, player in pairs(MPVehicleGE.getPlayers()) do 
+            if queuedPlayers[key] == nil then 
+                queuedPlayers[key] = false
             end
         end
     else 
         guihooks.trigger("resetQueueState")
     end
+
+	UIqueue = {spawnCount = spawnCount, editCount = editCount, queuedPlayers = queuedPlayers}
+	UIqueue.show = spawnCount+editCount > 0
+	sendQueue()
 end
 
 --- Used to set our ping in the top status bar. It also is used in the math for position prediction

--- a/mp_locales/en-US.json
+++ b/mp_locales/en-US.json
@@ -11,6 +11,8 @@
     "ui.options.multiplayer.queueSpawnEdit.tooltip": "If enabled, remote vehicle spawns and edits will be put in a queue, instead of applying instantly",
     "ui.options.multiplayer.queueAuto": "Automatically apply queued vehicle changes",
     "ui.options.multiplayer.queueAuto.tooltip": "If enabled, you will only spawn queued vehicles once you come to a stop based on the settings below",
+    "ui.options.multiplayer.highlightQueuedPlayers": "Highlight queued players",
+    "ui.options.multiplayer.highlightQueuedPlayers.tooltip": "Highlight players who have queued events in the playerlist",
     "ui.options.multiplayer.queueApplySpeed": "Queue apply speed threshold",
     "ui.options.multiplayer.queueApplySpeed.tooltip": "Queues apply if your vehicle moves slower than this speed",
     "ui.options.multiplayer.queueApplyTimeout": "Queue apply timeout",

--- a/settings/mp_defaults.json
+++ b/settings/mp_defaults.json
@@ -39,5 +39,6 @@
   "enablePosSmoother"           : [ "cloud", false ],
   "showPlayerIDs"               : [ "cloud", false ],
   "protectConfigFromClone"      : [ "cloud", false ],
-  "skipModSecurityWarning"      : [ "local", false ]
+  "skipModSecurityWarning"      : [ "local", false ],
+  "highlightQueuedPlayers"      : [ "local", true  ]
 }

--- a/ui/modules/apps/BeamMP-PlayerList/app.js
+++ b/ui/modules/apps/BeamMP-PlayerList/app.js
@@ -121,6 +121,8 @@ app.controller("PlayerList", ['$scope', function ($scope) {
 				// Insert a row at the end of the players list
 				var row = playersList.insertRow(playersList.rows.length);
 	
+				row.setAttribute("id", "playerlist-row-" + parsedList[i].id);
+
 				// Insert a cell containing the player server id
 				var idCell = row.insertCell(0);
 				idCell.textContent = parsedList[i].id;
@@ -138,7 +140,8 @@ app.controller("PlayerList", ['$scope', function ($scope) {
 				nameCell.textContent = parsedList[i].formatted_name;
 				//var c = parsedList[i].color
 				//nameCell.style = `color:rgba(${c[0]},${c[1]},${c[2]},255)`;
-				nameCell.setAttribute("onclick", "showPlayerInfo('"+parsedList[i].name+"')");
+				nameCell.setAttribute("oncontextmenu", "showPlayerInfo('"+parsedList[i].name+"')");
+				nameCell.setAttribute("onclick","applyQueuesForPlayer('"+parsedList[i].id+"')");
 				nameCell.setAttribute("class", "player-button");
 
 				// Insert a cell containing the link to forum
@@ -164,6 +167,10 @@ app.controller("PlayerList", ['$scope', function ($scope) {
 				btn.setAttribute("onclick","teleportToPlayer('"+parsedList[i]+"')");
 				btn.setAttribute("class", "tp-button buttons");
 				pingCell.appendChild(btn);
+
+				if ($scope.queuedPlayers[parsedList[i].id] == true) {
+					row.style.setProperty('background-color', 'var(--bng-orange-shade1)');
+				}
 			}
 			if(document.getElementById("plist-container").style.display == "block")
 				document.getElementById("show-button").style.height = playersList.offsetHeight + "px"; 
@@ -174,7 +181,26 @@ app.controller("PlayerList", ['$scope', function ($scope) {
 	$scope.$on('setNickname', function(event, data) {
 		nickname = data
 	})
-	bngApi.engineLua('UI.updatePlayersList()'); // insantly populate the playerlist
+
+	$scope.queuedPlayers = []
+
+	$scope.$on('setQueueState', function(event, data) {
+		$scope.queuedPlayers[data.playerID] = data.state
+		var playerrow = document.getElementById("playerlist-row-" + data.playerID)
+		if (playerrow) {
+			playerrow.style.setProperty('background-color', data.state ? 'var(--bng-orange-shade1)' : 'transparent')
+		}
+	})
+
+	$scope.$on('resetQueueState', function(event, data) {
+		$scope.queuedPlayers = []
+		var rows = document.querySelectorAll('[id^="playerlist-row-"]');
+		for (let i = 0; i < rows.length; i++) {
+			rows[i].style.setProperty('background-color', 'transparent');
+		}
+	})
+
+	bngApi.engineLua('UI.updatePlayersList(); MPVehicleGE.onUIInitialised()'); // instantly populate the playerlist and their queues
 }]);
 
 
@@ -195,6 +221,10 @@ function viewPlayer(targetPlayerName) {
 
 function restorePlayerVehicle(targetPlayerName){
     	bngApi.engineLua('MPVehicleGE.restorePlayerVehicle("'+targetPlayerName+'")')
+}
+
+function applyQueuesForPlayer(targetPlayerID) {
+	bngApi.engineLua('MPVehicleGE.applyPlayerQueues('+targetPlayerID+')')
 }
 
 function showPlayerInfo(targetPlayerName) {

--- a/ui/modules/apps/BeamMP-PlayerList/app.js
+++ b/ui/modules/apps/BeamMP-PlayerList/app.js
@@ -185,20 +185,21 @@ app.controller("PlayerList", ['$scope', function ($scope) {
 	$scope.queuedPlayers = []
 
 	$scope.$on('setQueue', function(event, data) {
+		if (!data.queuedPlayers) {
+			$scope.queuedPlayers = []
+			var rows = document.querySelectorAll('[id^="playerlist-row-"]');
+			for (let i = 0; i < rows.length; i++) {
+				rows[i].style.setProperty('background-color', 'transparent');
+			}
+			return
+		}
+
 		for (var key in data.queuedPlayers) {
 			$scope.queuedPlayers[key] = data.queuedPlayers[key]
 			var playerrow = document.getElementById("playerlist-row-" + key)
 			if (playerrow) {
 				playerrow.style.setProperty('background-color', data.queuedPlayers[key] ? 'var(--bng-orange-shade1)' : 'transparent')
 			}
-		}
-	})
-
-	$scope.$on('resetQueueState', function(event, data) {
-		$scope.queuedPlayers = []
-		var rows = document.querySelectorAll('[id^="playerlist-row-"]');
-		for (let i = 0; i < rows.length; i++) {
-			rows[i].style.setProperty('background-color', 'transparent');
 		}
 	})
 

--- a/ui/modules/apps/BeamMP-PlayerList/app.js
+++ b/ui/modules/apps/BeamMP-PlayerList/app.js
@@ -184,11 +184,13 @@ app.controller("PlayerList", ['$scope', function ($scope) {
 
 	$scope.queuedPlayers = []
 
-	$scope.$on('setQueueState', function(event, data) {
-		$scope.queuedPlayers[data.playerID] = data.state
-		var playerrow = document.getElementById("playerlist-row-" + data.playerID)
-		if (playerrow) {
-			playerrow.style.setProperty('background-color', data.state ? 'var(--bng-orange-shade1)' : 'transparent')
+	$scope.$on('setQueue', function(event, data) {
+		for (var key in data.queuedPlayers) {
+			$scope.queuedPlayers[key] = data.queuedPlayers[key]
+			var playerrow = document.getElementById("playerlist-row-" + key)
+			if (playerrow) {
+				playerrow.style.setProperty('background-color', data.queuedPlayers[key] ? 'var(--bng-orange-shade1)' : 'transparent')
+			}
 		}
 	})
 
@@ -200,7 +202,7 @@ app.controller("PlayerList", ['$scope', function ($scope) {
 		}
 	})
 
-	bngApi.engineLua('UI.updatePlayersList(); MPVehicleGE.onUIInitialised()'); // instantly populate the playerlist and their queues
+	bngApi.engineLua('UI.updatePlayersList(); UI.sendQueue()'); // instantly populate the playerlist and their queues
 }]);
 
 

--- a/ui/modules/options/multiplayer.partial.html
+++ b/ui/modules/options/multiplayer.partial.html
@@ -68,6 +68,12 @@
 
 <div class="mp-setting-border" ng-show="options.data.values.enableSpawnQueue">
   <md-list-item md-no-ink>
+    <p>{{:: 'ui.options.multiplayer.highlightQueuedPlayers' | translate }}</p>
+    <md-tooltip md-direction="right">{{:: 'ui.options.multiplayer.highlightQueuedPlayers.tooltip' | translate }}</md-tooltip>
+    <md-checkbox ng-model="options.data.values.highlightQueuedPlayers" ng-change="options.applyState()"></md-checkbox>
+  </md-list-item>
+
+  <md-list-item md-no-ink>
     <p>{{:: 'ui.options.multiplayer.queueAuto' | translate }}</p>
     <md-tooltip md-direction="right">{{:: 'ui.options.multiplayer.queueAuto.tooltip' | translate }}</md-tooltip>
     <md-checkbox ng-model="options.data.values.enableQueueAuto" ng-change="options.applyState()"></md-checkbox>


### PR DESCRIPTION
## The option to highlight players in the playerlist who have queued an event

<img width="930" alt="Checkbox option" src="https://github.com/user-attachments/assets/1ededc08-bc92-4d07-b1f3-a4333d56a37c">
Option to enable highlighting queued players, enabled by default.  
<br>
<br>

![image](https://github.com/user-attachments/assets/fdfd7300-ce1e-4457-9a17-82a84ea7aaf2)

Players that have a queue will light up in the playerlist.

Addresses issue #289.

---


## Selective queuing of players

https://github.com/user-attachments/assets/ece9cfc6-21e7-4a2b-b274-0dbe84e44157

Click on the name of the player whose queue you want to load.
Previously clicking on the name of a player put your camera at their vehicle, this functionality has been moved to right clicking on their name. This change can easily be reverted but in my opinion this is more intuitive.