### PR TITLE
fix for fatal lua error when joining servers

### DIFF
--- a/lua/ge/extensions/MPCoreNetwork.lua
+++ b/lua/ge/extensions/MPCoreNetwork.lua
@@ -612,7 +612,7 @@ runPostJoin = function() -- gets called once loaded into a map
 		MPGameNetwork.connectToLauncher()
 		log('W', 'runPostJoin', 'isGoingMpSession = false')
 		isGoingMpSession = false
-		--core_gamestate.setGameState('multiplayer', 'multiplayer', 'multiplayer')
+		core_gamestate.setGameState('multiplayer', 'multiplayer', 'multiplayer')
 		status = "Playing"
 		guihooks.trigger('onServerJoined')
 		if mp_core then


### PR DESCRIPTION
this line was commented out because it caused mission markers to get stuck on the map when changing maps, this seems to no longer be happening, though please test just in case I've just been very lucky, adding the line back gets rid of the fatal lua error when joining servers