### PR TITLE
Position and velocity improvements

### DIFF
--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1553,10 +1553,11 @@ local function onServerVehicleResetted(serverVehicleID, data)
 			local veh = be:getObjectByID(gameVehicleID) -- Get associated vehicle
 			if veh then
 				local pr = jsonDecode(data) -- Decoded data
-				veh:reset()
 				if pr then
 					veh:setPositionRotation(pr.pos.x, pr.pos.y, pr.pos.z, pr.rot.x, pr.rot.y, pr.rot.z, pr.rot.w) -- Apply position
+					veh:resetBrokenFlexMesh() -- setPositionRotation resets the vehicle but not the FlexMesh so we need to do that manually
 				else
+					veh:reset()
 					log('E', "onServerVehicleResetted", "Could not parse posrot JSON")
 				end
 			end

--- a/lua/ge/extensions/positionGE.lua
+++ b/lua/ge/extensions/positionGE.lua
@@ -210,14 +210,14 @@ local function setPositionRotationVelocity(gameVehicleID, positionData) -- this 
 	local rot = vehRot:inversed() * newRot
 	veh:setClusterPosRelRot(refNodeID, pos.x, pos.y, pos.z, rot.x, rot.y, rot.z, rot.w)
 
-	vel = vel - localVel:rotated(rot) --TODO check if cluster rotation also rotates velocity
+	vel = vel - localVel:rotated(rot) -- setClusterPosRelRot also rotates the velocity so we have to do that as well
 	veh:applyClusterVelocityScaleAdd(refNodeID, 1, vel.x, vel.y, vel.z) -- setting velocity with the GE command doesn't destroy vehicles so we set most of the velocity here
 
 	local noCounterVelocity = positionData.noCounter or 0
 	local onlyAngularVelocity = 1
 
 	-- but since it doesn't do rotational velocity we still need to use VE
-	-- somehow GE tp VE queues are really fast, so we don't need any extra prediction with this queue
+	-- apparently GE to VE queues are really fast, so we don't need any extra prediction with this queue
 	veh:queueLuaCommand("velocityVE.setAngularVelocity("..vel.x..", "..vel.y..", "..vel.z..", "..rvel.x..", "..rvel.y..", "..rvel.z..","..onlyAngularVelocity..","..noCounterVelocity..")")
 end
 

--- a/lua/ge/extensions/positionGE.lua
+++ b/lua/ge/extensions/positionGE.lua
@@ -191,6 +191,36 @@ local function setPosition(gameVehicleID, x, y, z) -- TODO: this is only here be
 	veh:setPositionNoPhysicsReset(Point3F(x, y, z))
 end
 
+local function setPositionRotationVelocity(gameVehicleID, positionData) -- this is done here because setting velocity and rotation in GE doesn't damage vehicles
+	local pos = positionData.pos
+	local newRot = positionData.rot
+	local vel = positionData.vel
+	local rvel = positionData.rvel
+	local veh = be:getObjectByID(gameVehicleID)
+
+	local localVel = veh:getVelocity()
+	local vehVel = positionData.vehVel
+
+	if math.abs(localVel.x) + math.abs(localVel.y) + math.abs(localVel.z) > (math.abs(vehVel.x) + math.abs(vehVel.y) + math.abs(vehVel.z))*5 then -- detect if velocity was a teleport
+		return
+	end
+
+	local refNodeID = veh:getRefNodeId()
+	local vehRot = quatFromDir(-veh:getDirectionVector(), veh:getDirectionVectorUp())
+	local rot = vehRot:inversed() * newRot
+	veh:setClusterPosRelRot(refNodeID, pos.x, pos.y, pos.z, rot.x, rot.y, rot.z, rot.w)
+
+	vel = vel - localVel:rotated(rot) --TODO check if cluster rotation also rotates velocity
+	veh:applyClusterVelocityScaleAdd(refNodeID, 1, vel.x, vel.y, vel.z) -- setting velocity with the GE command doesn't destroy vehicles so we set most of the velocity here
+
+	local noCounterVelocity = positionData.noCounter or 0
+	local onlyAngularVelocity = 1
+
+	-- but since it doesn't do rotational velocity we still need to use VE
+	-- somehow GE tp VE queues are really fast, so we don't need any extra prediction with this queue
+	veh:queueLuaCommand("velocityVE.setAngularVelocity("..vel.x..", "..vel.y..", "..vel.z..", "..rvel.x..", "..rvel.y..", "..rvel.z..","..onlyAngularVelocity..","..noCounterVelocity..")")
+end
+
 --- This function is used for setting the simulation speed 
 --- @param speed number
 local function setActualSimSpeed(speed)
@@ -228,17 +258,18 @@ local function onSettingsChanged()
 	end
 end
 
-M.applyPos          = applyPos
-M.tick              = tick
-M.handle            = handle
-M.sendVehiclePosRot = sendVehiclePosRot
-M.setPosition       = setPosition
-M.setPing           = setPing
-M.setActualSimSpeed = setActualSimSpeed
-M.getActualSimSpeed = getActualSimSpeed
-M.onPreRender       = onPreRender
-M.onSettingsChanged = onSettingsChanged
-M.posSmoother       = POSSMOOTHER -- debug entry
+M.applyPos                    = applyPos
+M.tick                        = tick
+M.handle                      = handle
+M.sendVehiclePosRot           = sendVehiclePosRot
+M.setPosition                 = setPosition
+M.setPositionRotationVelocity = setPositionRotationVelocity
+M.setPing                     = setPing
+M.setActualSimSpeed           = setActualSimSpeed
+M.getActualSimSpeed           = getActualSimSpeed
+M.onPreRender                 = onPreRender
+M.onSettingsChanged           = onSettingsChanged
+M.posSmoother                 = POSSMOOTHER -- debug entry
 M.onInit = function() setExtensionUnloadMode(M, "manual") end
 
 return M

--- a/lua/vehicle/extensions/BeamMP/positionVE.lua
+++ b/lua/vehicle/extensions/BeamMP/positionVE.lua
@@ -46,7 +46,7 @@ end
 -- Position
 local posCorrectMul = 5        -- How much velocity to use for correcting position error (m/s per m)
 local posForceMul = 5          -- How much acceleration is used to correct velocity
-local minPosForce = 0.07       -- If force is smaller than this, ignore to save performance
+local minPosForce = 0.04       -- If force is smaller than this, ignore to save performance
 local maxPosForce = 100        -- Maximum position correction force (m/s^2)
 local maxAcc = 100             -- Maximum acceleration in received data (m/s^2)
 local maxAccError = 3          -- If difference between target and actual acceleration larger than this, decrease force
@@ -54,7 +54,7 @@ local maxAccError = 3          -- If difference between target and actual accele
 -- Rotation
 local rotCorrectMul = 7        -- How much velocity to use for correcting angle error (rad/s per rad)
 local rotForceMul = 7          -- How much acceleration is used to correct angular velocity
-local minRotForce = 0.03       -- If force is smaller than this, ignore to save performance
+local minRotForce = 0.02       -- If force is smaller than this, ignore to save performance
 local maxRotForce = 50         -- Maximum rotation correction force (rad/s^2)
 local maxRacc = 50             -- Maximum angular acceleration in received data (rad/s^2)
 local maxRaccError = 3         -- If difference between target and actual angular acceleration larger than this, decrease force
@@ -359,7 +359,7 @@ local function updateGFX(dt)
 	--print("targetAcc: "..targetAcc:length())
 	--print("targetRacc: "..targetRacc:length())
 	if framesSinceReset > 5 then
-		if targetRacc:length() > minRotForce then
+		if targetRacc:length() > minRotForce or vehVel:length() > 1 then
 			velocityVE.addAngularVelocity(targetAcc.x, targetAcc.y, targetAcc.z, targetRacc.x, targetRacc.y, targetRacc.z)
 		elseif targetAcc:length() > minPosForce then
 			velocityVE.addVelocity(targetAcc.x, targetAcc.y, targetAcc.z)

--- a/lua/vehicle/extensions/BeamMP/velocityVE.lua
+++ b/lua/vehicle/extensions/BeamMP/velocityVE.lua
@@ -292,7 +292,7 @@ local function addAngularVelocity(x, y, z, pitchAV, rollAV, yawAV, onlyAngularVe
 end
 
 -- Instantly set vehicle angular velocity in rad/s
-local function setAngularVelocity(x, y, z, pitchAV, rollAV, yawAV, onlyAngularVelocity)
+local function setAngularVelocity(x, y, z, pitchAV, rollAV, yawAV, onlyAngularVelocity, noCounterVelocity)
 	local rot = quatFromDir(-vec3(obj:getDirectionVector()), vec3(obj:getDirectionVectorUp()))
 	local cog = M.cogRel:rotated(rot)
 	
@@ -304,7 +304,7 @@ local function setAngularVelocity(x, y, z, pitchAV, rollAV, yawAV, onlyAngularVe
 	local vvel = vec3(obj:getVelocity()) + cog:cross(vrvel)
 	local velDiff = vel - vvel
 	
-	addAngularVelocity(velDiff.x, velDiff.y, velDiff.z, rvelDiff.x, rvelDiff.y, rvelDiff.z, onlyAngularVelocity)
+	addAngularVelocity(velDiff.x, velDiff.y, velDiff.z, rvelDiff.x, rvelDiff.y, rvelDiff.z, onlyAngularVelocity, noCounterVelocity)
 end
 
 local function updateGFX(dt)

--- a/lua/vehicle/extensions/BeamMP/velocityVE.lua
+++ b/lua/vehicle/extensions/BeamMP/velocityVE.lua
@@ -14,12 +14,15 @@ local damageDelay = 0.2      -- How long to wait before recalculating connected 
 
 local connectedNodes = {}
 local nodes = {}
+local disconnectedNodes = {}
 local parentNode = nil
 local beamsChanged = false
 local lastDamage = 0
 local damageTimer = 0
 local physicsFPS = 0
 M.cogRel = vec3(0,0,0)
+
+local refNode = v.data.refNodes[0].ref
 
 -- Calculate center of gravity from connected nodes
 local function calcCOG()
@@ -53,9 +56,11 @@ local function findConnectedNodes()
 	--print("Find connected nodes "..obj:getId())
 	
 	nodes = {}
+	disconnectedNodes = {}
 	
 	local nodeStack = {}
 	local visited = {}
+	local connected = {}
 	local stackIdx = 1
 	
 	nodeStack[1] = parentNode
@@ -70,6 +75,7 @@ local function findConnectedNodes()
 		local nodePos = obj:getNodePosition(node)
 		
 		nodes[#nodes+1] = {node, nodeMass*physicsFPS}
+		connected[node] = 1
 		
 		cog:setAdd(nodePos*nodeMass)
 		totalMass = totalMass + nodeMass
@@ -94,7 +100,16 @@ local function findConnectedNodes()
 			end
 		end
 	end
-	
+
+	local refClusterID = obj:getNodeCluster(refNode)
+	for cid,_ in pairs(v.data.nodes) do
+		if not connected[cid] then
+			if obj:getNodeCluster(cid) == refClusterID then
+				local nodeMass = obj:getNodeMass(cid)
+				disconnectedNodes[#disconnectedNodes+1] = {cid, nodeMass*physicsFPS}
+			end
+		end
+	end
 	cog:setScaled(1/totalMass)
 	
 	local rot = quatFromDir(-obj:getDirectionVector(), obj:getDirectionVectorUp())
@@ -176,11 +191,30 @@ end
 -- How it works: Apply enough force to each node, so it accelerates to the target speed in 1 physics tick.
 --               Because all nodes accelerate at the same rate, the vehicle will not get ripped apart
 -- NOTE: - very high values can cause instability
-local function addVelocity(x, y, z)
+local function addForce(nodes, x, y, z, isCounterVel)
+	local mainClusterID = obj:getNodeCluster(refNode)
 	for i=1, #nodes do
 		local node = nodes[i]
-		
-		obj:applyForceVector(node[1], float3(x*node[2], y*node[2], z*node[2]))
+		if node then
+			if not isCounterVel or obj:getNodeCluster(node[1]) == mainClusterID then
+				obj:applyForceVector(node[1], float3(x*node[2], y*node[2], z*node[2]))
+			elseif isCounterVel then
+				table.remove(disconnectedNodes,i)
+			end
+		end
+	end
+end
+
+local function addVelocity(x, y, z)
+
+	local connectedNodeCount = #nodes
+	local disconnectedNodeCount = #disconnectedNodes
+
+	if connectedNodeCount < disconnectedNodeCount then
+		addForce(nodes, x, y, z)
+	else
+		obj:applyClusterLinearAngularAccel(refNode,vec3(x, y, z)*physicsFPS, vec3())
+		addForce(disconnectedNodes, -x, -y, -z, true)
 	end
 end
 
@@ -191,32 +225,64 @@ local function setVelocity(x, y, z)
 	addVelocity(x - vvel.x, y - vvel.y, z - vvel.z)
 end
 
-
 -- Add angular velocity to vehicle in rad/s
 -- How it works: Calculate node tangential velocity relative to car center of gravity at the desired angular velocity
 --               and apply enough force to reach the calculated speed in 1 physics tick.
 -- NOTE: - very high values can destroy vehicles (above about 20-30 rad/s for most cars) or cause instability
-local function addAngularVelocity(x, y, z, pitchAV, rollAV, yawAV)
+local function addAngularForce(nodes, x, y, z, pitchAV, rollAV, yawAV, isCounterVel)
 	local rot = quatFromDir(-vec3(obj:getDirectionVector()), vec3(obj:getDirectionVectorUp()))
 	local cog = M.cogRel:rotated(rot)
-	
+	local mainClusterID = obj:getNodeCluster(refNode)
 	--print("addAngularVelocity: pitchAV: "..pitchAV..", rollAV: "..rollAV..", yawAV: "..yawAV)
 	for i=1, #nodes do
 		local node = nodes[i]
-		local cid = node[1]
-		local mul = node[2]
-		local nodePos = obj:getNodePosition(cid)
-		local posX = nodePos.x - cog.x
-		local posY = nodePos.y - cog.y
-		local posZ = nodePos.z - cog.z
-		
-		-- Calculate linear force from torque axis and node position using vector cross product
-		-- doing this manually is ~3 times faster than vec3:cross(vec3)
-		local forceX = (x + posY * yawAV - posZ * rollAV)*mul
-		local forceY = (y + posZ * pitchAV - posX * yawAV)*mul
-		local forceZ = (z + posX * rollAV - posY * pitchAV)*mul
-		
-		obj:applyForceVector(cid, float3(forceX, forceY, forceZ))
+		if node then
+			local cid = node[1]
+			if not isCounterVel or obj:getNodeCluster(cid) == mainClusterID then
+				local mul = node[2]
+				local nodePos = obj:getNodePosition(cid)
+				local posX = nodePos.x - cog.x
+				local posY = nodePos.y - cog.y
+				local posZ = nodePos.z - cog.z
+				
+				-- Calculate linear force from torque axis and node position using vector cross product
+				-- doing this manually is ~3 times faster than vec3:cross(vec3)
+				local forceX = (x + posY * yawAV - posZ * rollAV)*mul
+				local forceY = (y + posZ * pitchAV - posX * yawAV)*mul
+				local forceZ = (z + posX * rollAV - posY * pitchAV)*mul
+				
+				obj:applyForceVector(cid, float3(forceX, forceY, forceZ))
+			elseif isCounterVel then
+				table.remove(disconnectedNodes,i)
+			end
+		end
+	end
+end
+
+local function addAngularVelocity(x, y, z, pitchAV, rollAV, yawAV)
+	local rot = quatFromDir(-vec3(obj:getDirectionVector()), vec3(obj:getDirectionVectorUp()))
+	local cog = M.cogRel:rotated(rot)
+	local vel = vec3(x, y, z) - cog:cross(vec3(pitchAV, rollAV, yawAV))
+
+	local connectedNodeCount = #nodes
+	local disconnectedNodeCount = #disconnectedNodes
+
+	if connectedNodeCount < disconnectedNodeCount then
+		addAngularForce(nodes, x, y, z, pitchAV, rollAV, yawAV)
+
+		local mainClusterID = obj:getNodeCluster(refNode)
+		for i=1, disconnectedNodeCount do
+			local node = disconnectedNodes[i]
+			if node then
+				if obj:getNodeCluster(node[1]) ~= mainClusterID then
+					table.remove(disconnectedNodes,i)
+				end
+			end
+		end
+	else
+		obj:applyClusterLinearAngularAccel(refNode,vel*physicsFPS, -vec3(pitchAV, rollAV, yawAV)*physicsFPS)
+
+		addAngularForce(disconnectedNodes, -x, -y, -z, -pitchAV, -rollAV, -yawAV, true)
 	end
 end
 


### PR DESCRIPTION
Implemented a hybrid between cluster velocity and applyForceVector to get the performance benefit of cluster Velocity but without doors flying away when support beams are still attached,
best case scenario the cluster velocity can be up to 9400% or 94 times faster
This gave me roughly a 12% fps boost, tested on gridmap_v2 with 16 D series with angular velocity forced on.

Improved teleports by using cluster teleport and instant velocity in GE which doesn't damage vehicles and also doesn't trigger crash detection,
i also added one frame of prediction so it teleports to where it should be after the VE > GE queue delay.

Fixed vehicles sometimes flickering back to previous reset point on resets.

Reduced minimum force values and made velocity always apply if vehicle is traveling faster than 1 meter per second, this makes cars wonder less from their actual position and stops oversteery cars from crabbing