### PR TITLE
Changed coupler attach method

### DIFF
--- a/lua/vehicle/extensions/BeamMP/couplerVE.lua
+++ b/lua/vehicle/extensions/BeamMP/couplerVE.lua
@@ -25,20 +25,18 @@ local function toggleCouplerState(data)
 	for k,v in pairs(decodedData) do
 		if v.state == false or v.state == true then
 			if v._nodetag then
-				if v.state then
-					local coupler = beamstate.couplerCache[v._nodetag]
-					if coupler then
+				local coupler = beamstate.couplerCache[v._nodetag]
+				if coupler then
+					if v.state then
 						obj:attachCoupler(coupler.cid, coupler.couplerTag or "", coupler.couplerStrength or 1000000, 10, coupler.couplerLockRadius or 0.025, 0.3, coupler.couplerTargets or 0)
 					else
-						dump("no cached coupler found with tag",v._nodetag)
+						obj:detachCoupler(v._nodetag, 0)
+						obj:queueGameEngineLua(string.format("onCouplerDetach(%s,%s)", obj:getId(), coupler.cid))
+						extensions.couplings.onBeamstateDetachCouplers()
 					end
 				else
-					obj:detachCoupler(v._nodetag, 0)
+					log("D", "couplerVE", "no cached coupler found with tag"..v._nodetag)
 				end
-			elseif v.state == false then
-				beamstate.disableAutoCoupling()
-				beamstate.detachCouplers()
-				obj:stopLatching()
 			end
 		elseif controller.getControllerSafe(v.name).getGroupState() ~= v.state then
 			local couplerController = {}

--- a/lua/vehicle/extensions/BeamMP/couplerVE.lua
+++ b/lua/vehicle/extensions/BeamMP/couplerVE.lua
@@ -15,14 +15,17 @@ local function toggleCouplerState(data)
 	local decodedData = jsonDecode(data)
 	for k,v in pairs(decodedData) do
 		if v.state == false or v.state == true then
-			if v._nodetag and not v.trailer then
+			if v._nodetag then
 				if v.state then
-					beamstate.attachCouplers(v._nodetag)
+					local coupler = beamstate.couplerCache[v._nodetag]
+					if coupler then
+						obj:attachCoupler(coupler.cid, coupler.couplerTag or "", coupler.couplerStrength or 1000000, 2, coupler.couplerLockRadius or 0.025, 0.3, coupler.couplerTargets or 0)
+					else
+						dump("no cached coupler")
+					end
 				else
 					obj:detachCoupler(v._nodetag, 0)
 				end
-			elseif v.state == true then
-				beamstate.activateAutoCoupling()
 			elseif v.state == false then
 				beamstate.disableAutoCoupling()
 				beamstate.detachCouplers()
@@ -52,7 +55,7 @@ local function onCouplerAttached(nodeId, obj2id, obj2nodeId, attachSpeed, attach
 		local Advanced = false
 		-- Advanced couplers, doors etc
 		local MPcouplerdata = {}
-		if timer <= 0 and ID == obj2id then
+		if ID == obj2id then
 			for k,v in pairs(MPcouplercache) do
 				local state = controller.getControllerSafe(v.name).getGroupState()
 				if v.state ~= state then
@@ -71,12 +74,6 @@ local function onCouplerAttached(nodeId, obj2id, obj2nodeId, attachSpeed, attach
 			local MPcouplers = {}
 			MPcouplers.state = true
 			MPcouplers._nodetag = nodeId
-			if ID == obj2id then -- checking if coupler is connecting to another vehicle
-				MPcouplers.trailer = false
-			else
-				MPcouplers.trailer = true
-			end
-			MPcouplers.obj2id = obj2id
 			table.insert(MPcouplerdata,MPcouplers)
 		end
 
@@ -94,7 +91,7 @@ local function onCouplerDetached(nodeId, obj2id, obj2nodeId)
 		local Advanced = false
 		-- Advanced couplers, doors etc
 		local MPcouplerdata = {}
-		if timer <= 0 and ID == obj2id then
+		if ID == obj2id then
 			for k,v in pairs(MPcouplercache) do
 				local state = controller.getControllerSafe(v.name).getGroupState()
 				if v.state ~= state then
@@ -113,12 +110,6 @@ local function onCouplerDetached(nodeId, obj2id, obj2nodeId)
 			local MPcouplers = {}
 			MPcouplers.state = false
 			MPcouplers._nodetag = nodeId
-			if ID == obj2id then -- checking if coupler is connecting to another vehicle
-				MPcouplers.trailer = false
-			else
-				MPcouplers.trailer = true
-			end
-			MPcouplers.obj2id = obj2id
 			table.insert(MPcouplerdata,MPcouplers)
 		end
 

--- a/lua/vehicle/extensions/BeamMP/couplerVE.lua
+++ b/lua/vehicle/extensions/BeamMP/couplerVE.lua
@@ -81,6 +81,12 @@ local function onCouplerAttached(nodeId, obj2id, obj2nodeId, attachSpeed, attach
 			local MPcouplers = {}
 			MPcouplers.state = true
 			MPcouplers._nodetag = nodeId
+			if ID == obj2id then -- checking if coupler is connecting to another vehicle
+				MPcouplers.trailer = false
+			else
+				MPcouplers.trailer = true
+			end
+			MPcouplers.obj2id = obj2id
 			table.insert(MPcouplerdata,MPcouplers)
 		end
 
@@ -117,6 +123,12 @@ local function onCouplerDetached(nodeId, obj2id, obj2nodeId)
 			local MPcouplers = {}
 			MPcouplers.state = false
 			MPcouplers._nodetag = nodeId
+			if ID == obj2id then -- checking if coupler is connecting to another vehicle
+				MPcouplers.trailer = false
+			else
+				MPcouplers.trailer = true
+			end
+			MPcouplers.obj2id = obj2id
 			table.insert(MPcouplerdata,MPcouplers)
 		end
 

--- a/lua/vehicle/extensions/BeamMP/couplerVE.lua
+++ b/lua/vehicle/extensions/BeamMP/couplerVE.lua
@@ -11,6 +11,15 @@ local lastNodeID2coupled
 local lastNodeIDdecoupled
 local lastNodeID2decoupled
 
+local originalActivateAutoCoupling = beamstate.activateAutoCoupling
+
+local function activateAutoCoupling(...)
+	if v.mpVehicleType and v.mpVehicleType == "R" then return end
+	originalActivateAutoCoupling(...)
+end
+
+beamstate.activateAutoCoupling = activateAutoCoupling
+
 local function toggleCouplerState(data)
 	local decodedData = jsonDecode(data)
 	for k,v in pairs(decodedData) do
@@ -19,9 +28,9 @@ local function toggleCouplerState(data)
 				if v.state then
 					local coupler = beamstate.couplerCache[v._nodetag]
 					if coupler then
-						obj:attachCoupler(coupler.cid, coupler.couplerTag or "", coupler.couplerStrength or 1000000, 2, coupler.couplerLockRadius or 0.025, 0.3, coupler.couplerTargets or 0)
+						obj:attachCoupler(coupler.cid, coupler.couplerTag or "", coupler.couplerStrength or 1000000, 10, coupler.couplerLockRadius or 0.025, 0.3, coupler.couplerTargets or 0)
 					else
-						dump("no cached coupler")
+						dump("no cached coupler found with tag",v._nodetag)
 					end
 				else
 					obj:detachCoupler(v._nodetag, 0)


### PR DESCRIPTION
changed coupling to attach the target node using obj:attachCoupler() rather than using activateAutoCoupling,
This stops the coupler debug blobs from activating on your screen when other are using trailers,
I've had to replace the activateAutoCoupling function to stop the blobs from activating when a remote vehicle with a trailer is reset.

This also helps the T series trailers to attach properly since it now tries to push and attach the coupler as long as it is within 10 meters