### PR TITLE
remove * from custom role

### DIFF
--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -494,12 +494,12 @@ function createRole(roleName, tag, shorttag, red, green, blue)
 	if tag == 0 then
 		contents["tag"] = ""
 	else
-		contents["tag"] = " [*" .. tag .. "]"
+		contents["tag"] = " [" .. tag .. "]"
 	end
 	if shorttag == 0 then
 		contents["shorttag"] = ""
 	else
-		contents["shorttag"] = " [*" .. shorttag .. "]"
+		contents["shorttag"] = " [" .. shorttag .. "]"
 	end
 	custom_roleToInfo[roleName] = contents
 	return true


### PR DESCRIPTION
You can literally upload malware to people who join your server, I think we can remove this star for the sake of people having cleaner roles, I could make a work around to make myself look like beamMP staff easily enough if I wanted to anyways