### PR TITLE
Fix for custom inputs

### DIFF
--- a/lua/vehicle/extensions/BeamMP/MPInputsVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPInputsVE.lua
@@ -95,7 +95,7 @@ local shortName = {
 local function getInputs()
 	local inputsToSend = {}
 	for inputName, _ in pairs(input.state) do
-		local state = electrics.values[inputName] -- the electric is the most accurate place to get the input value, the state.val is different with different filters and using the smoother states causes wrong inputs in arcade mode
+		local state = electrics.values[inputName] or electrics.values[inputName.."_input"] -- the electric is the most accurate place to get the input value, the state.val is different with different filters and using the smoother states causes wrong inputs in arcade mode
 		if state then
 			if inputName == "steering" then
 				if v.data.input then


### PR DESCRIPTION
Non default input actions have a "_input" appended to their corresponding electrics name, this PR makes those sync properly as well.

Tested to be working on cars, the Bell 407 mod and the Me262 mod.