### PR TITLE
fix drive modes being stuck in opposite state

### DIFF
--- a/lua/vehicle/extensions/BeamMP/MPElectricsVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPElectricsVE.lua
@@ -453,9 +453,6 @@ local function onReset()
 		electrics.values.absMode = settings.getValue("absBehavior", "realistic")
 	end
 	if v.mpVehicleType == "R" then
-		if controller.mainController.setGearboxMode then
-			controller.mainController.setGearboxMode("realistic")
-		end
 		if wheels then wheels.setABSBehavior(electrics.values.absMode or "realistic") end
 		localSwingwing = 0
 		remoteignition = true

--- a/lua/vehicle/extensions/BeamMP/MPInputsVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPInputsVE.lua
@@ -53,14 +53,20 @@ local function applyGear(data) --TODO: add handling for mismatched gearbox types
 			print('MPInputsVE Error in "applyGear()". Unsupported powertrain')
 		end
 		return nil
-	end 
-	
+	end
+
+	if electrics.values.gearboxMode and electrics.values.gearboxMode == "arcade" then
+		if controller.mainController.setGearboxMode then
+			controller.mainController.setGearboxMode("realistic")
+		end
+	end
+
 	-- certain gearbox need to be shifted with setGearIndex() while others need to be shifted with shiftXOnY()
 	if gearBoxHandler[powertrainDevice.type] == 1 then
 		local index = tonumber(data)
 		if not index then return end
 		powertrainDevice:setGearIndex(index)
-		
+
 	elseif gearBoxHandler[powertrainDevice.type] == 2 then
 		if electrics.values.isShifting then return end
 		local remoteGearMode = string.sub(data, 1, 1)
@@ -75,7 +81,7 @@ local function applyGear(data) --TODO: add handling for mismatched gearbox types
 		else
 			controller.mainController.shiftToGearIndex(translationTable[remoteGearMode])
 		end
-		
+
 	else
 		if not unsupportedPowertrainGearbox then
 			unsupportedPowertrainGearbox = true -- prevent spamming the log

--- a/lua/vehicle/extensions/BeamMP/MPPowertrainVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPPowertrainVE.lua
@@ -21,12 +21,9 @@ local devices = powertrain.getDevices()
 local function applyLivePowertrain(data)
 	controller.mainController.setGearboxMode("realistic")
 	local decodedData = jsonDecode(data) -- Decode data
-	for k, v in pairs(decodedData) do -- For each device	
-		--k = "gearbox"
-		--v.mode = "auto"
+	for k, v in pairs(decodedData) do -- For each device
 		if v.mode and devices[k] and devices[k].setMode then
-			powertrain.setDeviceMode(k, v.mode)
-			local gearIndex = v.gearIndex
+			devices[k].setMode(devices[k],v.mode)
 		end
 	end
 end

--- a/lua/vehicle/extensions/BeamMP/MPPowertrainVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPPowertrainVE.lua
@@ -19,7 +19,6 @@ local devices = powertrain.getDevices()
 
 
 local function applyLivePowertrain(data)
-	controller.mainController.setGearboxMode("realistic")
 	local decodedData = jsonDecode(data) -- Decode data
 	for k, v in pairs(decodedData) do -- For each device
 		if v.mode and devices[k] and devices[k].setMode then

--- a/lua/vehicle/extensions/BeamMP/syncedControllers/general.lua
+++ b/lua/vehicle/extensions/BeamMP/syncedControllers/general.lua
@@ -129,6 +129,20 @@ local function jatoRemoteUpdateGFX(controllerName, funcName, tempTable, ...) -- 
 	end
 end
 
+local function readDriveMode(controllerName, funcName, tempTable, ...)
+	local controller = controller.getControllerSafe(controllerName)
+	if controller then
+		controllerSyncVE.OGcontrollerFunctionsTable[controllerName][funcName](...)
+
+		tempTable.driveMode = controller.getCurrentDriveModeKey()
+		controllerSyncVE.sendControllerData(tempTable)
+	end
+end
+
+local function recieveDriveMode(data)
+	controllerSyncVE.OGcontrollerFunctionsTable[data.controllerName]["setDriveMode"](data.driveMode)
+end
+
 -- compare set to true only sends data when there is a change
 -- compare set to false sends the data every time the function is called
 -- adding ownerFunction and/or receiveFunction can set custom functions to read or change data before sending or on receiveing
@@ -154,8 +168,14 @@ local includedControllerTypes = {
 	
 	["driveModes"] = {
 		["setDriveMode"] = {},
-		["nextDriveMode"] = {},
-		["previousDriveMode"] = {},
+		["nextDriveMode"] = {
+			ownerFunction = readDriveMode,
+			receiveFunction = recieveDriveMode
+		},
+		["previousDriveMode"] = {
+			ownerFunction = readDriveMode,
+			receiveFunction = recieveDriveMode
+		},
 	},
 
 	["hydraulicSuspension"] = {


### PR DESCRIPTION
drive modes being a toggle makes the state wrong if it is in a different state to the spawn state when the car is spawned,
this fixes that by reading the state after the toggle function is called, then send that state and set's it on the receiving end