### PR TITLE
Add temporary popup when opening a url

### DIFF
--- a/lua/ge/extensions/MPCoreNetwork.lua
+++ b/lua/ge/extensions/MPCoreNetwork.lua
@@ -152,6 +152,8 @@ end
 local function openURL(url)
 	send("O"..url)
 	log('M', 'openURL', 'Requesting the BeamMP Launcher to open url: '..url)
+	-- Remove this when the url opening is in the public launcher release
+	guihooks.trigger('ConfirmationDialogOpen', "Link opened", "Please open  "..url.." in your browser if nothing happens.", "OK", "guihooks.trigger('ConfirmationDialogClose', 'Link opened')")
 end
 
 -- ================ UI ================


### PR DESCRIPTION
To be removed when a launcher with the url opening packet is released to public

![image](https://github.com/user-attachments/assets/21345d17-badb-4040-b229-d6a3f01aa74e)
