### PR TITLE
Potential workaround for sticky login UI

### DIFF
--- a/lua/ge/extensions/MPCoreNetwork.lua
+++ b/lua/ge/extensions/MPCoreNetwork.lua
@@ -167,6 +167,7 @@ end
 --- Returns true or false if the user is logged in.
 -- @return boolean loggedIn True if the user is logged in, false otherwise.
 local function isLoggedIn()
+	guihooks.trigger('actuallyLoggedIn', loggedIn)
 	return loggedIn
 end
 
@@ -604,6 +605,7 @@ end
 --- onLauncherConnected is an event which is called by internal scripts. This one is called when connection to the launcher is established
 --- @usage INTERNAL ONLY / GAME SPECIFIC
 onLauncherConnected = function()
+	loggedIn = false
 	reconnectAttempt = 0
 	log('W', 'onLauncherConnected', 'onLauncherConnected')
 	send('Z') -- request launcher version

--- a/ui/modules/multiplayer/multiplayer.js
+++ b/ui/modules/multiplayer/multiplayer.js
@@ -123,9 +123,13 @@ function($scope, $state, $timeout, $document) {
 		var x = document.getElementById('LOGINERRORFIELD').textContent= data;
 	});
 	
-	// Try to auto login
-	// bngApi.engineLua('MPCoreNetwork.autoLogin()');
-	// autologin is called from lua
+	//Workaround for sticky login UI
+	$scope.$on('actuallyLoggedIn', function (event, data) {
+		if (data == true) {
+			$state.go('menu.multiplayer.servers');
+		}
+	});
+	bngApi.engineLua('MPCoreNetwork.isLoggedIn()');
 }])
 
 


### PR DESCRIPTION
Sometimes the UI gets stuck on the login page despite the user being already logged in.
This is workaround that hopefully fixes that.