### PR TITLE
Add functionality to check that the server cversion is actually compatible with the Launcher Version.

### DIFF
--- a/lua/ge/extensions/MPCoreNetwork.lua
+++ b/lua/ge/extensions/MPCoreNetwork.lua
@@ -161,7 +161,7 @@ end
 -- Returns the version of the launcher.
 -- @return string version The version of the launcher.
 local function getLauncherVersion()
-	return "2.0" --launcherVersion
+	return launcherVersion
 end
 
 --- Returns true or false if the user is logged in.

--- a/ui/modules/multiplayer/multiplayer.js
+++ b/ui/modules/multiplayer/multiplayer.js
@@ -1447,7 +1447,11 @@ async function receiveServers(data) {
 	// Parse the data to a nice looking Array
 	for (var i = 0; i < data.length; i++) {
 		var v = data[i]
-		if(v.cversion == launcherVersion){
+		const [vMajor, vMinor] = v.cversion.split('.').map(Number);
+		const [launcherMajor, launcherMinor] = launcherVersion.split('.').map(Number);
+
+		// Compare the versions
+		if (vMajor === launcherMajor && launcherMinor >= vMinor) {
 			v.strippedName = stripCustomFormatting(v.sname);
 			serversArray.push(v);
 		}


### PR DESCRIPTION
This still needs to be fully tested with Launcher v2.2.X and Servers 3.6.X and below.