### PR TITLE
Fixed spawn rotations

### DIFF
--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1194,6 +1194,12 @@ local function applyVehSpawn(event)
 	local ignitionLevel  = (type(decodedData.ign) == "number") and decodedData.ign or 3
 	local protected      = decodedData.pro -- Config Protected
 
+	local vehicle = vehicles[event.serverVehicleID]
+	if vehicle and vehicle.position and vehicle.rotation then -- if we have receieved position packets then use that for position and rotation instead
+		pos = vec3(vehicle.position)
+		rot = quat(0,0,1,0) * quat(vehicle.rotation) -- the car rotates 180 degrees on spawn so we need to counter that
+	end
+
 	log('I', 'applyVehSpawn', "Spawning a vehicle from server with serverVehicleID "..event.serverVehicleID)
 	log('I', 'applyVehSpawn', "It is for "..event.playerNickname)
 

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1061,7 +1061,7 @@ local function sendVehicleSpawn(gameVehicleID)
 		local vehicleTable = {}
 		local vehicleData  = extensions.core_vehicle_manager.getVehicleData(gameVehicleID)
 		local pos          = veh:getPosition()
-		local rot          = quatFromDir(-vec3(veh:getDirectionVector()), vec3(veh:getDirectionVectorUp()))
+		local rot          = quat(veh:getRotation()) -- getRotation is the only correct one on spawn, but doesn't update so direction vectors are needed in other places
 
 		vehicleTable.pid = MPConfig.getPlayerServerID() -- Player Server ID
 		vehicleTable.vid = gameVehicleID -- Game Vehicle ID
@@ -1190,7 +1190,7 @@ local function applyVehSpawn(event)
 	local vehicleName    = decodedData.jbm -- Vehicle name
 	local vehicleConfig  = decodedData.vcf -- Vehicle config, contains paint data
 	local pos            = vec3(decodedData.pos)
-	local rot            = decodedData.rot.w and quat(decodedData.rot) or quat(0,0,0,0) --ensure the rotation data is good
+	local rot            = quat(0,0,1,0) * quat(decodedData.rot) -- the car rotates 180 degrees on spawn so we need to counter that
 	local ignitionLevel  = (type(decodedData.ign) == "number") and decodedData.ign or 3
 	local protected      = decodedData.pro -- Config Protected
 
@@ -1291,7 +1291,7 @@ local function applyVehEdit(serverID, data)
 		local options = {
 			model = vehicleName,
 			config = serialize(vehicleConfig),
-			pos = veh:getPosition(), rot = quatFromDir(-vec3(veh:getDirectionVector()), vec3(veh:getDirectionVectorUp())), cling = true,
+			pos = veh:getPosition(), rot = quat(0,0,1,0) *  quatFromDir(-vec3(veh:getDirectionVector()), vec3(veh:getDirectionVectorUp())), cling = true,
 		}
 
 		veh:setDynDataFieldbyName("autoEnterVehicle", 0, tostring((be:getPlayerVehicle(0) and be:getPlayerVehicle(0):getID() == gameVehicleID) or false))

--- a/lua/ge/extensions/positionGE.lua
+++ b/lua/ge/extensions/positionGE.lua
@@ -78,10 +78,14 @@ local function applyPos(decoded, serverVehicleID)
 	local vehicle = MPVehicleGE.getVehicleByServerID(serverVehicleID)
 	if not vehicle then log('E', 'applyPos', 'Could not find vehicle by ID '..serverVehicleID) return end
 
-	local simspeedFraction = 1/simTimeAuthority.getReal()
 
-	for k,v in pairs(decoded.vel) do decoded.vel[k] = v*simspeedFraction end
-	for k,v in pairs(decoded.rvel) do decoded.rvel[k] = v*simspeedFraction end
+	local simspeedFraction = 1
+	local gameSpeed = simTimeAuthority.getReal()
+	if gameSpeed > 0 then
+		simspeedFraction = 1/gameSpeed
+		for k,v in pairs(decoded.vel) do decoded.vel[k] = v*simspeedFraction end
+		for k,v in pairs(decoded.rvel) do decoded.rvel[k] = v*simspeedFraction end
+	end
 
 	decoded.localSimspeed = simspeedFraction
 


### PR DESCRIPTION
on vehicle spawn the rotations where never applied so the car was always facing the same direction, and when doing edits the car spawned rotated by 180 degrees, this PR fixed both of those,

I've also made it use received position and rotation packets if they exist,

Finally i added a check to the sim speed so it doesn't divide by 0 if the game reports the wrong speed