### PR TITLE
Add missing simple traffic vehicles

### DIFF
--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -758,7 +758,7 @@ local vehicleSimplifiers = {
 		local parts = vehicleConfig.parts
 		local newModel = "simple_traffic"
 
-		parts.simple_traffic_model = "simple_traffic_suburst_body"
+		parts.simple_traffic_model = "simple_traffic_sunburst_body"
 		parts.simple_traffic_sunburst_bumper_F = parts.sunburst_bumper_F == "" and "" or nil
 		parts.simple_traffic_sunburst_bumper_R = parts.sunburst_bumper_R == "" and "" or nil
 		parts.simple_traffic_sunburst_hood = parts.sunburst_hood == "" and "" or nil
@@ -813,7 +813,7 @@ local vehicleSimplifiers = {
 		local parts = vehicleConfig.parts
 		local newModel = "simple_traffic"
 
-		parts.simple_traffic_model = "simple_traffic_vivace_body"
+		parts.simple_traffic_model = "simple_traffic_vivace"
 		if string.find(parts.tograc_bumper_F or "", "tograc_bumper_F") then
 			parts.simple_traffic_vivace_bumper_F_tograc = "simple_traffic_vivace_bumper_F_tograc"
 		else
@@ -839,7 +839,7 @@ local vehicleSimplifiers = {
 		local parts = vehicleConfig.parts
 		local newModel = "simple_traffic"
 
-		parts.simple_traffic_model = "simple_traffic_wendover_body"
+		parts.simple_traffic_model = "simple_traffic_wendover"
 		parts.simple_traffic_wendover_bumper_F = parts.wendover_bumper_F == "" and "" or nil
 		parts.simple_traffic_wendover_bumper_R = parts.wendover_bumper_R == "" and "" or nil
 		parts.simple_traffic_wendover_hood = parts.wendover_hood == "" and "" or nil

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -809,6 +809,32 @@ local vehicleSimplifiers = {
 		vehicleConfig.mainPartName = newModel
 		return newModel
 	end,
+	vivace = function(vehicleConfig)
+		local parts = vehicleConfig.parts
+		local newModel = "simple_traffic"
+
+		parts.simple_traffic_model = "simple_traffic_vivace_body"
+		if string.find(parts.tograc_bumper_F or "", "tograc_bumper_F") then
+			parts.simple_traffic_vivace_bumper_F_tograc = "simple_traffic_vivace_bumper_F_tograc"
+		else
+			parts.simple_traffic_vivace_bumper_F_vivace = parts.vivace_bumper_F == "" and "" or nil
+		end
+		if string.find(parts.tograc_bumper_R or "", "tograc_bumper_R") then
+			parts.simple_traffic_vivace_bumper_R_tograc = "simple_traffic_vivace_bumper_R_tograc"
+		else
+			parts.simple_traffic_vivace_bumper_R_vivace = parts.vivace_bumper_R == "" and "" or nil
+		end
+		if string.find(parts.tograc_hood or "", "tograc_hood") then
+			parts.simple_traffic_vivace_hood_tograc = "simple_traffic_vivace_hood_tograc"
+		else
+			parts.simple_traffic_vivace_hood_vivace = parts.vivace_hood == "" and "" or nil
+		end
+		parts.simple_traffic_vivace_trunk = parts.vivace_trunk == "" and "" or nil
+
+		vehicleConfig.model = newModel
+		vehicleConfig.mainPartName = newModel
+		return newModel
+	end,
 	wendover = function(vehicleConfig)
 		local parts = vehicleConfig.parts
 		local newModel = "simple_traffic"

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -758,7 +758,7 @@ local vehicleSimplifiers = {
 		local parts = vehicleConfig.parts
 		local newModel = "simple_traffic"
 
-		parts.simple_traffic_model = "simple_traffic_sunburst_body"
+		parts.simple_traffic_model = "simple_traffic_sunburst"
 		parts.simple_traffic_sunburst_bumper_F = parts.sunburst_bumper_F == "" and "" or nil
 		parts.simple_traffic_sunburst_bumper_R = parts.sunburst_bumper_R == "" and "" or nil
 		parts.simple_traffic_sunburst_hood = parts.sunburst_hood == "" and "" or nil

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -814,17 +814,17 @@ local vehicleSimplifiers = {
 		local newModel = "simple_traffic"
 
 		parts.simple_traffic_model = "simple_traffic_vivace"
-		if string.find(parts.tograc_bumper_F or "", "tograc_bumper_F") then
+		if string.find(parts.vivace_bumper_F or "", "tograc_bumper_F") then
 			parts.simple_traffic_vivace_bumper_F_tograc = "simple_traffic_vivace_bumper_F_tograc"
 		else
 			parts.simple_traffic_vivace_bumper_F_vivace = parts.vivace_bumper_F == "" and "" or nil
 		end
-		if string.find(parts.tograc_bumper_R or "", "tograc_bumper_R") then
+		if string.find(parts.vivace_bumper_R or "", "tograc_bumper_R") then
 			parts.simple_traffic_vivace_bumper_R_tograc = "simple_traffic_vivace_bumper_R_tograc"
 		else
 			parts.simple_traffic_vivace_bumper_R_vivace = parts.vivace_bumper_R == "" and "" or nil
 		end
-		if string.find(parts.tograc_hood or "", "tograc_hood") then
+		if string.find(parts.vivace_hood or "", "tograc_hood") then
 			parts.simple_traffic_vivace_hood_tograc = "simple_traffic_vivace_hood_tograc"
 		else
 			parts.simple_traffic_vivace_hood_vivace = parts.vivace_hood == "" and "" or nil

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -754,6 +754,20 @@ local vehicleSimplifiers = {
 		vehicleConfig.mainPartName = newModel
 		return newModel
 	end,
+	sunburst = function(vehicleConfig)
+		local parts = vehicleConfig.parts
+		local newModel = "simple_traffic"
+
+		parts.simple_traffic_model = "simple_traffic_suburst_body"
+		parts.simple_traffic_sunburst_bumper_F = parts.sunburst_bumper_F == "" and "" or nil
+		parts.simple_traffic_sunburst_bumper_R = parts.sunburst_bumper_R == "" and "" or nil
+		parts.simple_traffic_sunburst_hood = parts.sunburst_hood == "" and "" or nil
+		parts.simple_traffic_sunburst_trunk = parts.sunburst_trunk == "" and "" or nil
+
+		vehicleConfig.model = newModel
+		vehicleConfig.mainPartName = newModel
+		return newModel
+	end,
 	van = function(vehicleConfig)
 		local parts = vehicleConfig.parts
 		local newModel = "simple_traffic"

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -574,6 +574,20 @@ local vehicleSimplifiers = {
 		vehicleConfig.mainPartName = newModel
 		return newModel
 	end,
+	etkc = function(vehicleConfig)
+		local parts = vehicleConfig.parts
+		local newModel = "simple_traffic"
+
+		parts.simple_traffic_model = "simple_traffic_etkc_body"
+		parts.simple_traffic_etkc_bumper_F = parts.etkc_bumper_F == "" and "" or nil
+		parts.simple_traffic_etkc_bumper_R = parts.etkc_bumper_R == "" and "" or nil
+		parts.simple_traffic_etkc_hood = parts.etki_hood == "" and "" or nil
+		parts.simple_traffic_etkc_trunk = parts.etki_trunk == "" and "" or nil
+
+		vehicleConfig.model = newModel
+		vehicleConfig.mainPartName = newModel
+		return newModel
+	end,
 	etki = function(vehicleConfig)
 		local parts = vehicleConfig.parts
 		local newModel = "simple_traffic"

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -809,6 +809,20 @@ local vehicleSimplifiers = {
 		vehicleConfig.mainPartName = newModel
 		return newModel
 	end,
+	wendover = function(vehicleConfig)
+		local parts = vehicleConfig.parts
+		local newModel = "simple_traffic"
+
+		parts.simple_traffic_model = "simple_traffic_wendover_body"
+		parts.simple_traffic_wendover_bumper_F = parts.wendover_bumper_F == "" and "" or nil
+		parts.simple_traffic_wendover_bumper_R = parts.wendover_bumper_R == "" and "" or nil
+		parts.simple_traffic_wendover_hood = parts.wendover_hood == "" and "" or nil
+		parts.simple_traffic_wendover_trunk = parts.wendover_trunk == "" and "" or nil
+
+		vehicleConfig.model = newModel
+		vehicleConfig.mainPartName = newModel
+		return newModel
+	end,
 }
 
 --- modify the given vehicleConfig so it as closely resembles the original config with simplified vehicle, or not touched if simplified vehicle not possible


### PR DESCRIPTION
Adds ETK C, Sunburst, Vivace and Wendover to the list of simplified vehicles

Fixes https://github.com/BeamMP/BeamMP/issues/697