### PR TITLE
Add "patching" behaviour to AddEventHandler, add RemoveEventHandler and pcall called event functions

### DIFF
--- a/lua/ge/extensions/MPGameNetwork.lua
+++ b/lua/ge/extensions/MPGameNetwork.lua
@@ -189,13 +189,14 @@ function TriggerClientEvent(name, data)
 end
 
 --- Adds an event handler for the specified event name and function.
--- @tparam string name - The name of the event
+-- @tparam string event_name - The name of the event
 -- @tparam function func - The event handler function
+-- @tparam string name - The internal name (optional)
 -- @usage AddEventHandler(`<name>`, `<function>`)
 -- @usage if AddEventHandler then AddEventHandler(`<name>`, `<function>`) end -- if your mod is also singleplayer available
-function AddEventHandler(name, func)
-	if name == nil or type(name) ~= "string" or (type(name) == "string" and name:len() == 0) then
-		log('E', 'BeamMP - AddEventHandler', 'Error, given name is not a valid string name')
+function AddEventHandler(event_name, func, name)
+	if event_name == nil or type(event_name) ~= "string" or (type(event_name) == "string" and event_name:len() == 0) then
+		log('E', 'BeamMP - AddEventHandler', 'Error, given event_name is not a valid string name')
 		return
 	end
 	if (func == nil or func == nop) or type(func) ~= "function" then
@@ -203,16 +204,16 @@ function AddEventHandler(name, func)
 		return
 	end
 	
-	local source = debug.getinfo(2).source
+	local source = name or debug.getinfo(2).source
 	if source == nil or source:len() == 0 then
 		log('E', 'BeamMP - AddEventHandler', 'Error, invalid source of event')
 		return
 	end
 	
-	local calls = eventTriggers[name]
+	local calls = eventTriggers[event_name]
 	if not calls then
 		calls = {}
-		eventTriggers[name] = calls
+		eventTriggers[event_name] = calls
 	end
 	
 	local patch = false
@@ -229,15 +230,48 @@ function AddEventHandler(name, func)
 	end
 	
 	if not patch then
-		log('M', 'BeamMP - AddEventHandler', 'Adding new Event Handler to "' .. name .. '"')
+		log('M', 'BeamMP - AddEventHandler', 'Adding new Event Handler to "' .. event_name .. '" from source "' .. source .. '"')
 	else
-		log('M', 'BeamMP - AddEventHandler', 'Patching Event Handler from "' .. name .. '"')
+		log('M', 'BeamMP - AddEventHandler', 'Patching Event Handler from "' .. event_name .. '" from source "' .. source .. '"')
 	end
 	
 	table.insert(calls, {
 		source = source,
 		func = func
 	})
+end
+
+--- Removes an event handler for the specified event name
+-- @tparam string event_name - The name of the event
+-- @tparam string name - The internal name (optional)
+-- @usage RemoveEventHandler(`<name>`, `<function>`)
+function RemoveEventHandler(event_name, name)
+	if event_name == nil or type(event_name) ~= "string" or (type(event_name) == "string" and event_name:len() == 0) then
+		log('E', 'BeamMP - RemoveEventHandler', 'Error, given event_name is not a valid string name')
+		return
+	end
+	local source = name or debug.getinfo(2).source
+	if source == nil or source:len() == 0 then
+		log('E', 'BeamMP - RemoveEventHandler', 'Error, invalid source of event')
+		return
+	end
+	
+	local calls = eventTriggers[event_name]
+	if not calls then
+		log('E', 'BeamMP - RemoveEventHandler', '"' .. event_name .. '" is unknown')
+		return
+	end
+	
+	for index, call in ipairs(calls) do
+		if call.source == source then
+			local max = #calls
+			calls[index] = calls[max]
+			calls[max] = nil
+			log('I', 'BeamMP - RemoveEventHandler', '"' .. event_name .. '" has been removed from source "' .. source .. '"')
+			return
+		end
+	end
+	log('E', 'BeamMP - RemoveEventHandler', '"' .. event_name .. '" is unknown from source "' .. source .. '"')
 end
 
 -- -----------------------------------------------------------------------------

--- a/lua/ge/extensions/MPGameNetwork.lua
+++ b/lua/ge/extensions/MPGameNetwork.lua
@@ -17,6 +17,13 @@ local socket = require('socket')
 local TCPLauncherSocket = nop
 local launcherConnected = false
 local isConnecting = false
+
+--[[ Format
+	["eventname"] = table
+		[1..n] = table
+			[source] = path to source
+			[func] = function
+]]
 local eventTriggers = {}
 
 --keypress handling
@@ -154,12 +161,13 @@ end
 --- Handles events triggered by MP.TriggerClientEvent send from the Server or localy with TriggerClientEvent.
 -- @tparam string p The event data to be parsed and handled. Should be in the format ":<NAME>:<DATA>"
 -- @usage MPGameNetwork.CallEvent(`<event data string>`)
-local function handleEvents(p)  --- code=E  p=:<NAME>:<DATA>
-	local eventName, eventData = string.match(p,"^%:([^%:]+)%:(.*)")
-	if not eventName then quitMP(p) return end
-	for i=1,#eventTriggers do
-		if eventTriggers[i].name == eventName then
-			if type(eventTriggers[i].func) == "function" then eventTriggers[i].func(eventData) end
+local function handleEvents(p)
+	local name, data = string.match(p,"^%:([^%:]+)%:(.*)")
+	if not name then quitMP(p) return end
+	for _, calls in ipairs(eventTriggers[name] or {}) do
+		local ok, err = pcall(calls.func, data)
+		if not ok then
+			log('E', 'BeamMP - handleEvents', err)
 		end
 	end
 end
@@ -181,17 +189,55 @@ function TriggerClientEvent(name, data)
 end
 
 --- Adds an event handler for the specified event name and function.
--- @tparam string n - The name of the event
--- @tparam function f - The event handler function
+-- @tparam string name - The name of the event
+-- @tparam function func - The event handler function
 -- @usage AddEventHandler(`<name>`, `<function>`)
 -- @usage if AddEventHandler then AddEventHandler(`<name>`, `<function>`) end -- if your mod is also singleplayer available
-function AddEventHandler(n, f)
-	log('M', 'AddEventHandler', "Adding Event Handler: Name = "..tostring(n))
-	if type(f) ~= "function" or f == nop then
-		log('W', 'AddEventHandler', "Event handler function can not be nil")
-	else
-		table.insert(eventTriggers, {name = n, func = f})
+function AddEventHandler(name, func)
+	if name == nil or type(name) ~= "string" or (type(name) == "string" and name:len() == 0) then
+		log('E', 'BeamMP - AddEventHandler', 'Error, given name is not a valid string name')
+		return
 	end
+	if (func == nil or func == nop) or type(func) ~= "function" then
+		log('E', 'BeamMP - AddEventHandler', 'Error, given function is not a valid function')
+		return
+	end
+	
+	local source = debug.getinfo(2).source
+	if source == nil or source:len() == 0 then
+		log('E', 'BeamMP - AddEventHandler', 'Error, invalid source of event')
+		return
+	end
+	
+	local calls = eventTriggers[name]
+	if not calls then
+		calls = {}
+		eventTriggers[name] = calls
+	end
+	
+	local patch = false
+	for index, call in ipairs(calls) do
+		if call.source == source then
+			patch = true
+			local max = #calls
+			calls[index] = calls[max]
+			if max > 1 then
+				calls[max] = nil
+			end
+			break
+		end
+	end
+	
+	if not patch then
+		log('M', 'BeamMP - AddEventHandler', 'Adding new Event Handler to "' .. name .. '"')
+	else
+		log('M', 'BeamMP - AddEventHandler', 'Patching Event Handler from "' .. name .. '"')
+	end
+	
+	table.insert(calls, {
+		source = source,
+		func = func
+	})
 end
 
 -- -----------------------------------------------------------------------------


### PR DESCRIPTION
This solves the following issue.

```lua
local function myEventFunction()
   -- do something
end

AddEventHandler("myEvent", myEventFunction)
AddEventHandler("myEvent", myEventFunction)
```

This function will now be twice in `eventTriggers`. This issue is easy to trigger when the extension that listens to beammp events is hotreloaded.

This behaviour is changed with this PR. AddEventHandler will now lookup if it already knows of this event and if so patch the function instead of just adding it again. Multiple functions can still listen to the same event. The check is performed via `debug.getinfo(2).source`

So this introduces the limitation that a lua file can only have 1 function listen per event it wants to listen to
```lua
local function myEventFunction()
   -- do something
end

local function myEventFunction2()
   -- do something
end

AddEventHandler("myEvent", myEventFunction)
AddEventHandler("myEvent", myEventFunction) -- will replace the previous
AddEventHandler("myEvent2", myEventFunction2) -- will work
AddEventHandler("myEvent", myEventFunction2) -- will also work
```


![grafik](https://github.com/user-attachments/assets/af0d5919-70c2-45ae-9bc9-d05d45706d5e)
