### PR TITLE
Add option to disable the mod if the launcher isn't open

### DIFF
--- a/lua/ge/extensions/MPConfig.lua
+++ b/lua/ge/extensions/MPConfig.lua
@@ -84,7 +84,9 @@ local defaultSettings = {
 
 	playerlistLeftclick = 0, -- 0 - queue events, 1 - switch camera, 2 - open forum, 3 - delete, 4 - restore, 5 - copy name
 
-	launcherPort = 4444
+	launcherPort = 4444,
+
+	disableWithoutLauncher = false,
 }
 
 --- Called when the mod is loaded by the games modloader. 

--- a/lua/ge/extensions/MPCoreNetwork.lua
+++ b/lua/ge/extensions/MPCoreNetwork.lua
@@ -92,7 +92,11 @@ local function send(s)
 			authResult = {}
 			guihooks.trigger("authReceived", authResult)
 		elseif error == "Socket is not connected" then
-
+			if settings.getValue("disableWithoutLauncher") then
+				core_modmanager.deactivateMod("beammp")
+				core_modmanager.deactivateMod("multiplayerbeammp")
+				log('W', 'send', 'Launcher not connected! Deactivating mod!')
+			end
 		else
 			log('E', 'send', 'Stopped at index: '..index..' while trying to send '..#s..' bytes of data.')
 		end

--- a/lua/ge/extensions/MPCoreNetwork.lua
+++ b/lua/ge/extensions/MPCoreNetwork.lua
@@ -93,9 +93,12 @@ local function send(s)
 			guihooks.trigger("authReceived", authResult)
 		elseif error == "Socket is not connected" then
 			if settings.getValue("disableWithoutLauncher") then
-				core_modmanager.deactivateMod("beammp")
-				core_modmanager.deactivateMod("multiplayerbeammp")
-				log('W', 'send', 'Launcher not connected! Deactivating mod!')
+				local mods = core_modmanager.getMods()
+				if (mods.beammp or mods.multiplayerbeammp or {}).active then
+					core_modmanager.deactivateMod("beammp")
+					core_modmanager.deactivateMod("multiplayerbeammp")
+					log('W', 'send', 'Launcher not connected! Deactivating mod!')
+				end
 			end
 		else
 			log('E', 'send', 'Stopped at index: '..index..' while trying to send '..#s..' bytes of data.')

--- a/mp_locales/en-US.json
+++ b/mp_locales/en-US.json
@@ -88,6 +88,8 @@
     "ui.options.multiplayer.experimental": "EXPERIMENTAL",
     "ui.options.multiplayer.refreshIngame": "Allow the serverlist to refresh ingame",
     "ui.options.multiplayer.refreshIngame.tooltip": "Wether to allow the serverlist to refresh whilst in a session. Enabling this can cause lag spikes.",
+    "ui.options.multiplayer.disableWithoutLauncher": "Disable multiplayer without launcher",
+    "ui.options.multiplayer.disableWithoutLauncher.tooltip": "Disables BeamMP when the launcher isn't present.",
     "ui.multiplayer.multiplayer": "Multiplayer",
     "ui.multiplayer.connecting": "Connecting",
     "ui.multiplayer.connectingToServer": "Connecting to server...",

--- a/settings/mp_defaults.json
+++ b/settings/mp_defaults.json
@@ -42,5 +42,6 @@
   "skipModSecurityWarning"      : [ "local", false ],
   "highlightQueuedPlayers"      : [ "local", true  ],
   "playerlistLeftclick"         : [ "cloud", 0 ],
-  "refreshIngame"               : [ "local", false ]
+  "refreshIngame"               : [ "local", false ],
+  "disconnectedWarningFrequency": [ "cloud", 5 ]
 }

--- a/ui/modules/options/multiplayer.partial.html
+++ b/ui/modules/options/multiplayer.partial.html
@@ -347,6 +347,13 @@
   <span ng-if="options.data.values.launcherPort == 4444" style="margin-left:15px">({{:: 'ui.common.default' | translate}})</span>
 </md-list-item>
 
+<md-list-item md-no-ink ng-show="options.data.values.showAdvancedMPOptions">
+  <md-tooltip md-direction="right">{{:: 'ui.options.multiplayer.disableWithoutLauncher.tooltip' | translate }}</md-tooltip>
+  <p>{{:: 'ui.options.multiplayer.disableWithoutLauncher' | translate }}</p>
+  <md-checkbox ng-model="options.data.values.disableWithoutLauncher" ng-change="options.applyState()"></md-checkbox>
+</md-list-item>
+
+
 <!--<md-list-item md-no-ink>
     <md-tooltip md-direction="right">{{:: 'ui.options.multiplayer.clearLauncherCache.tooltip' | translate }}</md-tooltip>
     <p>{{:: 'ui.options.multiplayer.clearLauncherCache' | translate }}</p>


### PR DESCRIPTION
If the game was started without the launcher and the intention is to play singleplayer, this option can be used. And this will not be an inconvenience if the user does want to play BeamMP as the launcher enables the mod before launching the game.