### PR TITLE
Fix fatal in MPCoreNetwork.onUpdate() from processing invalid data

### DIFF
--- a/lua/ge/extensions/MPCoreNetwork.lua
+++ b/lua/ge/extensions/MPCoreNetwork.lua
@@ -629,17 +629,19 @@ local function onUpdate(dt)
 		if TCPLauncherSocket ~= nop then
 			while(true) do
 				local received, stat, partial = TCPLauncherSocket:receive()
-				if not received or received == "" then
+				if not received or received:len() == 0 then
 					break
-				end
-				if settings.getValue("showDebugOutput") then -- TODO: add option to filter out heartbeat packets
-					log('M', 'onUpdate', 'Receiving Data ('..#received..'): '..received)
 				end
 
 				-- break it up into code + data
 				local code = string.sub(received, 1, 1)
 				local data = string.sub(received, 2)
-				HandleNetwork[code](data)
+				
+				if settings.getValue("showDebugOutput") and code ~= 'A' then
+					log('M', 'onUpdate', 'Receiving Data ([' .. code .. ']' .. #received .. '): ' .. received)
+				end
+				
+				if HandleNetwork[code] then HandleNetwork[code](data) end
 			end
 		end
 		--================================ SECONDS TIMER ================================

--- a/lua/ge/extensions/MPCoreNetwork.lua
+++ b/lua/ge/extensions/MPCoreNetwork.lua
@@ -641,7 +641,11 @@ local function onUpdate(dt)
 					log('M', 'onUpdate', 'Receiving Data ([' .. code .. ']' .. #received .. '): ' .. received)
 				end
 				
-				if HandleNetwork[code] then HandleNetwork[code](data) end
+				if not HandleNetwork[code] then
+					log('E', 'onUpdate', 'Received corrupted packet fragment. Ignoring data.')
+				else
+					HandleNetwork[code](data)
+				end
 			end
 		end
 		--================================ SECONDS TIMER ================================

--- a/lua/ge/extensions/MPCoreNetwork.lua
+++ b/lua/ge/extensions/MPCoreNetwork.lua
@@ -637,12 +637,12 @@ local function onUpdate(dt)
 				local code = string.sub(received, 1, 1)
 				local data = string.sub(received, 2)
 				
-				if settings.getValue("showDebugOutput") and code ~= 'A' then
-					log('M', 'onUpdate', 'Receiving Data ([' .. code .. ']' .. #received .. '): ' .. received)
+				if settings.getValue("showDebugOutput") then -- TODO: add option to filter out heartbeat packets
+					log('M', 'onUpdate', 'Receiving Data ([' .. code .. '] ' .. #received .. '): ' .. received)
 				end
 				
 				if not HandleNetwork[code] then
-					log('E', 'onUpdate', 'Received corrupted packet fragment. Ignoring data.')
+					log('E', 'onUpdate', 'Received corrupted packet fragment ([' .. code .. '] ' .. #received .. '): ' .. received)
 				else
 					HandleNetwork[code](data)
 				end


### PR DESCRIPTION
The game own socket.tcp() class seems to be configured to auto split received data by newlines which are then given back from the `:receive()` method used by beammp. Unfortunately the class fails todo so at times and either doesnt split data at all or merges it with other.

This leads to corrupted and unfixable data on the receiving end. i cannot find the origin of this behaviour and would change it if i could, but given that the Launcher -> Game protocol works with newlines as packet seperators i see no way to cleanly seperate packets any other way.

As such this is merely a troubleshoot. Please be aware that this fix throws the received data away (not that it would help if it didnt)