### PR TITLE
Fix pairs function for scenetree objects

### DIFF
--- a/lua/ge/extensions/MPHelpers.lua
+++ b/lua/ge/extensions/MPHelpers.lua
@@ -232,7 +232,7 @@ local _pairs = pairs
 function pairs (value) 
 	local g = getmetatable(value) 
 	if g then 
-		if type(g.__pairs) == "function" then 
+		if type(rawget(g, "__pairs")) == "function" then 
 			return g.__pairs(value) 
 		else 
 			return _pairs(value) 


### PR DESCRIPTION
This small change fixes some issues when iterating over scenetree objects using the pairs function.
The regular access of .__pairs triggers the __index function on metatables which can crash the game if you do it on scenetree objects where the function doesnt exist.