### PR TITLE
Fix selected row in serverlist having a bonus column because of .focus-visible class since 0.36

### DIFF
--- a/ui/modModules/multiplayer/multiplayer.css
+++ b/ui/modModules/multiplayer/multiplayer.css
@@ -437,6 +437,9 @@ md-slider.ng-pristine.ng-untouched.ng-valid.md-default-theme.ng-empty {
 }
 
 
+#serverListMainContainer .focus-visible::before {     
+  display: none; 
+}
 
 .server-item {
     height: 24px;
@@ -464,6 +467,7 @@ md-slider.ng-pristine.ng-untouched.ng-valid.md-default-theme.ng-empty {
 .offline {
   background-color: rgba(0, 0, 0, 0.35);
 }
+
 .color-0 { color: #000000; }
 .color-1 { color: #0000AA; }
 .color-2 { color: #00AA00; }


### PR DESCRIPTION
This fix the weird behavior of the selected row in the serverlist since 0.36, i dont really know why this beamng class apply on the row like this though