### PR TITLE
Fix Launcher -> Game message loss (v2 Networking)

### DIFF
--- a/lua/ge/extensions/MPCoreNetwork.lua
+++ b/lua/ge/extensions/MPCoreNetwork.lua
@@ -21,6 +21,7 @@ local ltn12 = require("ltn12")
 local launcherConnected = false
 local isConnecting = false
 local proxyPort = ""
+local socketPartialData
 local launcherVersion = "" -- used only for the server list
 local modVersion = "4.16.0" -- the mod version
 -- server
@@ -120,6 +121,7 @@ local function connectToLauncher(silent)
 	isConnecting = true
 	if not silent then log('W', 'connectToLauncher', "connectToLauncher called! Current connection status: "..tostring(launcherConnected)) end
 	if not launcherConnected and not mp_core then
+		socketPartialData = nil
 		TCPLauncherSocket = socket.tcp()
 		TCPLauncherSocket:setoption("keepalive", true) -- Keepalive to avoid connection closing too quickly
 		TCPLauncherSocket:settimeout(0) -- Set timeout to 0 to avoid freezing
@@ -142,6 +144,7 @@ local function disconnectLauncher(reconnect)
 		TCPLauncherSocket:close()
 		launcherConnected = false
 		isGoingMpSession = false
+		socketPartialData = nil
 	end
 	if reconnect then connectToLauncher() end
 end
@@ -628,7 +631,8 @@ local function onUpdate(dt)
 
 		if TCPLauncherSocket ~= nop then
 			while(true) do
-				local received, stat, partial = TCPLauncherSocket:receive()
+				local received, stat, partial = TCPLauncherSocket:receive('*l', socketPartialData)
+				socketPartialData = partial
 				if not received or received:len() == 0 then
 					break
 				end

--- a/lua/ge/extensions/MPGameNetwork.lua
+++ b/lua/ge/extensions/MPGameNetwork.lua
@@ -17,6 +17,7 @@ local socket = require('socket')
 local TCPLauncherSocket = nop
 local launcherConnected = false
 local isConnecting = false
+local socketPartialData
 
 --[[ Format
 	["eventname"] = table
@@ -53,6 +54,7 @@ local function connectToLauncher()
 	log('M', 'connectToLauncher', "Connecting MPGameNetwork!")
 	if not launcherConnected then
 		isConnecting = true
+		socketPartialData = nil
 		TCPLauncherSocket = socket.tcp()
 		TCPLauncherSocket:setoption("keepalive", true)
 		TCPLauncherSocket:settimeout(0) -- Set timeout to 0 to avoid freezing
@@ -74,6 +76,7 @@ local function disconnectLauncher()
 	if launcherConnected then
 		TCPLauncherSocket:close()
 		launcherConnected = false
+		socketPartialData = nil
 	end
 end
 
@@ -478,7 +481,8 @@ local function onUpdate(dt)
 	if launcherConnected then
 		if TCPLauncherSocket ~= nop then
 			while(true) do
-				local received, status, partial = TCPLauncherSocket:receive() -- Receive data
+				local received, status, partial = TCPLauncherSocket:receive('*l', socketPartialData) -- Receive data
+				socketPartialData = partial
 				if received == nil or received == "" then break end
 
 				if settings.getValue("showDebugOutput") == true then


### PR DESCRIPTION
Since [the launcher sends the message data and the ending newline via separate calls to send](https://github.com/BeamMP/BeamMP-Launcher/blob/e7cfb6e406a96d2f57ab5c35a69439bf447da63a/src/Network/GlobalHandler.cpp#L83), it's possible for the game to receive a message's data but not the following newline in a call to `receive`. This is considered a `timeout` error and the partial message data is returned in the `partial` result--but this was being ignored, resulting in the message being effectively lost. It is already read, and thus isn't included in future reads.

This seems to be a much more prevalent issue when running the client natively on Linux, and seems to be more noticeable in `MPGameNetwork`, resulting in vehicle events, chat messages, server-triggered events, and possibly more being silently dropped.

This should address https://github.com/BeamMP/BeamMP/issues/763.