### PR TITLE
Fixed name sorting in the serverlist by using strippedName instead of sname

### DIFF
--- a/ui/modModules/multiplayer/servers.partial.html
+++ b/ui/modModules/multiplayer/servers.partial.html
@@ -117,7 +117,7 @@
 			<thead id="serversTableHead">
 				<tr id="header">
 					<th class="server-flag" ng-click="sortTable('location', false)">{{:: 'ui.multiplayer.location' | translate}}</th>
-					<th class="server-servername" ng-click="sortTable('sname', false)">{{:: 'ui.multiplayer.description' | translate}}</th>
+					<th class="server-servername" ng-click="sortTable('strippedName', false)">{{:: 'ui.multiplayer.description' | translate}}</th>
 					<th class="server-mapname" ng-click="sortTable('map', false)" style="min-width: 200px;">{{:: 'ui.multiplayer.map' | translate}}</th>
 					<th class="server-maxplayers" ng-click="sortTable('players', true)">{{:: 'ui.multiplayer.players' | translate}}</th>
 				</tr>


### PR DESCRIPTION
The colors symbol was messing with the sort, so it's fixed by using strippedName