### PR TITLE
[Fix] Change from debugDrawer:drawTextAdvanced to ffi.C.BNG_DBG_DRAW_TextAdvanced to regain control over Z rendering + option

### DIFF
--- a/lua/ge/extensions/MPConfig.lua
+++ b/lua/ge/extensions/MPConfig.lua
@@ -60,7 +60,7 @@ local function setDefaultUnicycle(configFileName)
 end
 
 local defaultSettings = {
-	autoSyncVehicles = true, nameTagShowDistance = true, enableBlobs = true, showSpectators = true, nametagCharLimit = 32, showPlayerIDs = false,
+	autoSyncVehicles = true, nameTagShowDistance = true, enableBlobs = true, showSpectators = true, nametagCharLimit = 32, showPlayerIDs = false, nameTagsHideBehindObjects = false,
 	-- queue system
 	enableSpawnQueue = true, enableQueueAuto = true, queueSkipUnicycle = true, queueApplySpeed = 2, queueApplyTimeout = 3, highlightQueuedPlayers = true,
 	-- colors

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -32,6 +32,10 @@ local original_spawnNewVehicle
 local original_replaceVehicle
 local original_spawnDefault
 
+-- the debugDrawer functions without draw in the name calls FFI directly, these runs a lot faster and produces no garbage,
+-- however it requires xyz to be input independently, check lua\common\utils\debugDraw.lua to see the available functions
+local debugDrawer2 = require("utils/debugDraw")
+local drawTextAdvanced = debugDrawer2.TextAdvanced
 
 --- Contains Information about Backend authorized Roles
 -- @table roleToInfo
@@ -2434,7 +2438,7 @@ local function onPreRender(dt)
 				local name = v.customName or ownerName
 
 				local tag = settings.getValue("shortenNametags") and roleInfo.shorttag or roleInfo.tag
-				local backColor = ColorI(roleInfo.backcolor.r, roleInfo.backcolor.g, roleInfo.backcolor.b, math.floor(nametagAlpha*127))
+				local backColor = color(roleInfo.backcolor.r, roleInfo.backcolor.g, roleInfo.backcolor.b, math.floor(nametagAlpha*127))
 
 				local prefix = ""
 				for source, tag in pairs(owner.nickPrefixes)
@@ -2461,24 +2465,32 @@ local function onPreRender(dt)
 					if spectators ~= "" then
 						local spectatorBackColor = backColor
 						if settings.getValue("spectatorUnifiedColors") then
-							spectatorBackColor = ColorI(roleToInfo.USER.backcolor.r, roleToInfo.USER.backcolor.g, roleToInfo.USER.backcolor.b, math.floor(nametagAlpha*127))
+							spectatorBackColor = color(roleToInfo.USER.backcolor.r, roleToInfo.USER.backcolor.g, roleToInfo.USER.backcolor.b, math.floor(nametagAlpha*127))
 						end
-						debugDrawer:drawTextAdvanced(
-							pos, -- Location
+						drawTextAdvanced(
+							pos.x, pos.y, pos.z, -- Location
 							String(" ".. spectators .." "), -- Text
-							ColorF(1, 1, 1, nametagAlpha), true, false, -- Foreground Color / Draw background / Wtf
-							spectatorBackColor) -- Background Color
+							color(255, 255, 255, nametagAlpha*254), -- Foreground Color, Alpha is multiplied by 254 because using 255 seems to break backround alpha in 0.37
+							true, -- Draw background 
+							false, -- Wtf
+							spectatorBackColor, -- Background Color
+							false, -- shadow
+							settings.getValue("nameTagsHideBehindObjects") -- useZ, makes it render behind objects if true
+						)
 
 						pos.z = pos.z + 0.01 -- has to be positive
 					end
 				end
-
 				-- draw main nametag
-				debugDrawer:drawTextAdvanced(
-					pos, -- Location
+				drawTextAdvanced(
+					pos.x, pos.y, pos.z, -- Location
 					String(" " .. table.concat({prefix, name, suffix, tag, dist}) .. " "), -- Text
-					ColorF(1, 1, 1, nametagAlpha), true, false, -- Foreground Color / Draw background / Wtf
-					backColor -- Background Color
+					color(255, 255, 255, nametagAlpha*254), -- Foreground Color, Alpha is multiplied by 254 because using 255 seems to break backround alpha in 0.37
+					true, -- Draw background 
+					false, -- Wtf
+					backColor, -- Background Color
+					false, -- shadow
+					settings.getValue("nameTagsHideBehindObjects") -- useZ, makes it render behind objects if true
 				)
 			end
 			:: skip_vehicle ::

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -32,10 +32,13 @@ local original_spawnNewVehicle
 local original_replaceVehicle
 local original_spawnDefault
 
--- the debugDrawer functions without draw in the name calls FFI directly, these runs a lot faster and produces no garbage,
--- however it requires xyz to be input independently, check lua\common\utils\debugDraw.lua to see the available functions
-local debugDrawer2 = require("utils/debugDraw")
-local drawTextAdvanced = debugDrawer2.TextAdvanced
+local ffiFound = false
+if ffi and ffi.C then
+	ffiFound = true
+end
+
+-- debug drawers, using the FFI functions for debugDraw is a lot faster and produces no garbage
+local drawTextAdvanced = ffiFound and ffi.C.BNG_DBG_DRAW_TextAdvanced or nop
 
 --- Contains Information about Backend authorized Roles
 -- @table roleToInfo

--- a/mp_locales/en-US.json
+++ b/mp_locales/en-US.json
@@ -30,6 +30,7 @@
     "ui.options.multiplayer.nameTags": "Hide player nametags",
     "ui.options.multiplayer.nameTagAlternate": "Use alternate nametag colors",
     "ui.options.multiplayer.nameTagShowDistance": "Show distance from other players",
+    "ui.options.multiplayer.nameTagsHideBehindObjects": "Hide nametags behind objects",
     "ui.options.multiplayer.debugOutput": "Show network activity in the console",
     "ui.options.multiplayer.launcherPort": "Launcher port:[br]Don't change unless you have to",
     "ui.options.multiplayer.launcherPortWarn": "Don't change unless you have to",

--- a/ui/modules/options/multiplayer.partial.html
+++ b/ui/modules/options/multiplayer.partial.html
@@ -265,6 +265,11 @@
   <md-checkbox ng-model="options.data.values.nameTagShowDistance" ng-change="options.applyState()"></md-checkbox>
 </md-list-item>
 
+<md-list-item md-no-ink>
+  <p>{{:: 'ui.options.multiplayer.nameTagsHideBehindObjects' | translate }}</p>
+  <md-checkbox ng-model="options.data.values.nameTagsHideBehindObjects" ng-change="options.applyState()"></md-checkbox>
+</md-list-item>
+
 <md-list-item md-no-ink ng-show="options.data.values.showAdvancedMPOptions">
   <p>{{:: 'ui.options.multiplayer.nametagFade' | translate }}</p>
   <md-checkbox ng-model="options.data.values.nameTagFadeEnabled" ng-change="options.applyState()"></md-checkbox>


### PR DESCRIPTION
Nametags now render on top of everything again by default, but i added an option to enable the z buffer again

fixed render alpha by switching to the FFI drawer, the other one seems bugged? the FFI drawer should also be a lot faster and produce a lot less less garbage

the nametags seem to be a bit more transparent now, but I'm not sure if that's just me, maybe something to double check and adjust if necessary