### PR TITLE
hide mission markers while in multiplayer session

### DIFF
--- a/lua/ge/extensions/MPCoreNetwork.lua
+++ b/lua/ge/extensions/MPCoreNetwork.lua
@@ -707,7 +707,7 @@ runPostJoin = function() -- gets called once loaded into a map
 		MPGameNetwork.connectToLauncher()
 		log('W', 'runPostJoin', 'isGoingMpSession = false')
 		isGoingMpSession = false
-		core_gamestate.setGameState('freeroam', 'multiplayer', 'multiplayer')
+		core_gamestate.setGameState('multiplayer', 'multiplayer', 'multiplayer')
 		status = "Playing"
 		guihooks.trigger('onServerJoined')
 		if mp_core then

--- a/lua/ge/extensions/multiplayer/multiplayer.lua
+++ b/lua/ge/extensions/multiplayer/multiplayer.lua
@@ -121,7 +121,7 @@ local function onWorldReadyState(state)
 	if state == 2 then
 		if MPCoreNetwork and MPCoreNetwork.isMPSession() then
 			log('M', 'onWorldReadyState', 'Setting game state to multiplayer.')
-			core_gamestate.setGameState('freeroam', 'multiplayer', 'multiplayer')
+			core_gamestate.setGameState('multiplayer', 'multiplayer', 'multiplayer')
 			local spawnDefaultGroups = { "CameraSpawnPoints", "PlayerSpawnPoints", "PlayerDropPoints", "spawnpoints" }
 
 			for i, v in pairs(spawnDefaultGroups) do

--- a/lua/ge/extensions/multiplayer/multiplayer.lua
+++ b/lua/ge/extensions/multiplayer/multiplayer.lua
@@ -84,8 +84,6 @@ local function onDeactivateBigMapCallback()
 	end
 end
 
-M.onDeactivateBigMapCallback = onDeactivateBigMapCallback
-
 
 --- onUpdate is a game eventloop function. It is called each frame by the game engine.
 --- This is the main processing thread of BeamMP in the game
@@ -146,7 +144,7 @@ local function onServerLeave()
 	if originalToggleWalkingMode and gameplay_walk and gameplay_walk.toggleWalkingMode then gameplay_walk.toggleWalkingMode = originalToggleWalkingMode end
 	if original_markerInteraction_isStateFreeroam then gameplay_markerInteraction.isStateFreeroam = original_markerInteraction_isStateFreeroam end
 	if original_markerInteraction_onPreRender then gameplay_markerInteraction.onPreRender = original_markerInteraction_onPreRender end
-	gameplay_markerInteraction.setMarkersVisibleTemporary(true)
+	if gameplay_markerInteraction then gameplay_markerInteraction.setMarkersVisibleTemporary(true) end
 end
 
 
@@ -194,6 +192,7 @@ end
 M.onUpdate          = onUpdate
 M.onWorldReadyState = onWorldReadyState
 M.onBigMapActivated = onBigMapActivated
+M.onDeactivateBigMapCallback = onDeactivateBigMapCallback
 M.runPostJoin = runPostJoin
 M.onServerLeave = onServerLeave
 M.onInit = function() setExtensionUnloadMode(M, "manual") end

--- a/lua/ge/extensions/multiplayer/multiplayer.lua
+++ b/lua/ge/extensions/multiplayer/multiplayer.lua
@@ -192,6 +192,7 @@ end
 M.onUpdate          = onUpdate
 M.onWorldReadyState = onWorldReadyState
 M.onBigMapActivated = onBigMapActivated
+M.onNavigateToMission = onDeactivateBigMapCallback
 M.onDeactivateBigMapCallback = onDeactivateBigMapCallback
 M.runPostJoin = runPostJoin
 M.onServerLeave = onServerLeave

--- a/lua/ge/extensions/multiplayer/multiplayer.lua
+++ b/lua/ge/extensions/multiplayer/multiplayer.lua
@@ -15,6 +15,7 @@ local M = {state={}}
 local originalGetDriverData
 local originalToggleWalkingMode
 local original_onInstabilityDetected
+local original_markerInteraction_isStateFreeroam
 local original_markerInteraction_onPreRender
 
 --- Custom GetDriverData for allowing the getting of the right hand door or not for passenger aspects.
@@ -53,6 +54,12 @@ local function modified_onInstabilityDetected(jbeamFilename)
 	log('E', "", "Instability detected for vehicle " .. tostring(jbeamFilename))
 end
 
+local function modified_markerInteraction_isStateFreeroam()
+	if core_gamestate.state and (core_gamestate.state.state == "freeroam" or core_gamestate.state.state == 'career' or  core_gamestate.state.state == 'multiplayer') then
+		return true
+	end
+	return false
+end
 
 local function hideAllMissionMarkers()
 	if not gameplay_playmodeMarkers then return end
@@ -121,7 +128,10 @@ local function runPostJoin()
 	onInstabilityDetected = modified_onInstabilityDetected
 
 	if gameplay_markerInteraction then
+		original_markerInteraction_isStateFreeroam = gameplay_markerInteraction.isStateFreeroam
 		original_markerInteraction_onPreRender = gameplay_markerInteraction.onPreRender
+
+		gameplay_markerInteraction.isStateFreeroam = modified_markerInteraction_isStateFreeroam
 		gameplay_markerInteraction.onPreRender = nop
 		gameplay_markerInteraction.setMarkersVisibleTemporary(false)
 		hideAllMissionMarkers()
@@ -134,6 +144,7 @@ local function onServerLeave()
 	if original_onInstabilityDetected then onInstabilityDetected = original_onInstabilityDetected end
 	if originalGetDriverData then core_camera.getDriverData = originalGetDriverData end
 	if originalToggleWalkingMode and gameplay_walk and gameplay_walk.toggleWalkingMode then gameplay_walk.toggleWalkingMode = originalToggleWalkingMode end
+	if original_markerInteraction_isStateFreeroam then gameplay_markerInteraction.isStateFreeroam = original_markerInteraction_isStateFreeroam end
 	if original_markerInteraction_onPreRender then gameplay_markerInteraction.onPreRender = original_markerInteraction_onPreRender end
 	gameplay_markerInteraction.setMarkersVisibleTemporary(true)
 end

--- a/lua/ge/extensions/multiplayer/multiplayer.lua
+++ b/lua/ge/extensions/multiplayer/multiplayer.lua
@@ -194,6 +194,7 @@ M.onWorldReadyState = onWorldReadyState
 M.onBigMapActivated = onBigMapActivated
 M.onNavigateToMission = onDeactivateBigMapCallback
 M.onDeactivateBigMapCallback = onDeactivateBigMapCallback
+M.onUiChangedState = onDeactivateBigMapCallback
 M.runPostJoin = runPostJoin
 M.onServerLeave = onServerLeave
 M.onInit = function() setExtensionUnloadMode(M, "manual") end

--- a/lua/ge/extensions/multiplayer/multiplayer.lua
+++ b/lua/ge/extensions/multiplayer/multiplayer.lua
@@ -15,7 +15,7 @@ local M = {state={}}
 local originalGetDriverData
 local originalToggleWalkingMode
 local original_onInstabilityDetected
-
+local original_markerInteraction_onPreRender
 
 --- Custom GetDriverData for allowing the getting of the right hand door or not for passenger aspects.
 --- @param veh userdata The vehicle data
@@ -54,12 +54,30 @@ local function modified_onInstabilityDetected(jbeamFilename)
 end
 
 
+local function hideAllMissionMarkers()
+	if not gameplay_playmodeMarkers then return end
+
+	for i, cluster in ipairs(gameplay_playmodeMarkers.getPlaymodeClusters()) do
+		local marker = gameplay_playmodeMarkers.getMarkerForCluster(cluster)
+		marker:hide()
+	end
+end
+
 --- Called when the Big Map is loaded by the user. 
 local function onBigMapActivated() -- don't pause the game when opening the Big Map
 	if MPCoreNetwork and MPCoreNetwork.isMPSession() then
 		simTimeAuthority.pause(false)
+		hideAllMissionMarkers()
 	end
 end
+
+local function onDeactivateBigMapCallback()
+	if MPCoreNetwork and MPCoreNetwork.isMPSession() then
+		hideAllMissionMarkers()
+	end
+end
+
+M.onDeactivateBigMapCallback = onDeactivateBigMapCallback
 
 
 --- onUpdate is a game eventloop function. It is called each frame by the game engine.
@@ -101,6 +119,13 @@ local function runPostJoin()
 		onInstabilityDetected = modified_onInstabilityDetected
 	end
 	onInstabilityDetected = modified_onInstabilityDetected
+
+	if gameplay_markerInteraction then
+		original_markerInteraction_onPreRender = gameplay_markerInteraction.onPreRender
+		gameplay_markerInteraction.onPreRender = nop
+		gameplay_markerInteraction.setMarkersVisibleTemporary(false)
+		hideAllMissionMarkers()
+	end
 end
 
 
@@ -109,6 +134,8 @@ local function onServerLeave()
 	if original_onInstabilityDetected then onInstabilityDetected = original_onInstabilityDetected end
 	if originalGetDriverData then core_camera.getDriverData = originalGetDriverData end
 	if originalToggleWalkingMode and gameplay_walk and gameplay_walk.toggleWalkingMode then gameplay_walk.toggleWalkingMode = originalToggleWalkingMode end
+	if original_markerInteraction_onPreRender then gameplay_markerInteraction.onPreRender = original_markerInteraction_onPreRender end
+	gameplay_markerInteraction.setMarkersVisibleTemporary(true)
 end
 
 


### PR DESCRIPTION
This is also an alternative fix for the Minimap lag without setting the state to freeroam,

at first i tried just patching that function like suggested, and while that worked for the lag issue, it also had the problem of the missions being visible, this workaround should fix both

The game seems to have several places where it sets them to visible,
setMarkersVisibleTemporary worked for markers when the map is not open,
however if you quick traveled to one it would still render that one, and you could start that challenge even after clearing the marker table,
Removing onPreRender and hiding them manually is the only way i found to solved that so far, while doing it this way feels a bit hacky, it should be fine for now.

The markers still render in the big map, so you can still use the travel points, however as soon as you exit the map or quick travel they all disappear again.

All of this reverts as you leave the session, so the markers and map should still work as expected outside of multiplayer