### PR TITLE
Changed the name of favorite servers when added from direct connect

### DIFF
--- a/ui/modModules/multiplayer/multiplayer.js
+++ b/ui/modModules/multiplayer/multiplayer.js
@@ -662,7 +662,7 @@ function($scope, $state, $timeout, $mdDialog, $filter, ConfirmationDialog, toast
 
 		var valid = (ip.length > 0) && (port.length > 0) && !isNaN(port)
 		if (!valid) return;
-		var name = ip + ":" + port;
+		var name = new Date().toLocaleString()
 		var server = {
 			cversion: await getLauncherVersion(), ip: ip, location: "--", map: "", maxplayers: "0", players: "0",
 			owner: "", playersList: "", sdesc: "", sname: name, strippedName: name,


### PR DESCRIPTION
Currently if you save a server as favorite from the direct connect tab it will use the IP and Port as the name,
This makes it show the server IP and Port at the top of the screen when in the server, Which makes it very easy to accidentally leak the server IP of a private server
here I've have changed it to use time and date instead

Ideally we would prompt the user to add a name, but i don't have enough UI experience to be able to do that