### PR TITLE
Update multiplayer.uilayout.json

### DIFF
--- a/settings/ui_apps/layouts/default/multiplayer.uilayout.json
+++ b/settings/ui_apps/layouts/default/multiplayer.uilayout.json
@@ -14,15 +14,6 @@
       }
     },
     {
-      "appName":"keyList",
-      "placement":{
-        "width":"355px",
-        "height":"500px",
-        "right":"0px",
-        "top":"0px"
-      }
-    },
-    {
       "appName":"simplePowertrainControl",
       "placement":{
         "bottom":"0px",
@@ -30,9 +21,6 @@
         "position":"absolute",
         "right":"260px",
         "width":"230px"
-      },
-      "settings":{
-        "noCockpit":true
       }
     },
     {
@@ -49,6 +37,7 @@
     },
     {
       "appName":"tacho2",
+      "appVersion":1,
       "placement":{
         "width":"300px",
         "bottom":"5px",
@@ -71,7 +60,20 @@
         "width":"470px"
       }
     },
-	    {
+    {
+      "appName":"inputHints",
+      "appVersion":4,
+      "placement":{
+        "bottom":"480px",
+        "height":"",
+        "left":"",
+        "position":"absolute",
+        "right":"0px",
+        "top":"",
+        "width":"330px"
+      }
+    },
+	  {
       "appName":"multiplayerchat",
       "placement":{
         "width":"550px",
@@ -83,11 +85,13 @@
     {
       "appName":"multiplayerplayerlist",
       "placement":{
-        "height":"527px",
-        "min-width":"240px",
+        "bottom":"",
+        "height":"560px",
+        "left":"",
+        "position":"absolute",
         "right":"0px",
-        "top":"90px",
-        "width":"auto"
+        "top":"30px",
+        "width":"300px"
       }
     },
     {


### PR DESCRIPTION
the included ui app layout in beammp uses the outdated keyList app and seems to have a bug with the playerlist width, this addresses both of those by bringing in a replica of the default freeroam ui app layout and fixing a couple lines in the mp playerlist ui app placement

<img width="2553" height="1388" alt="image" src="https://github.com/user-attachments/assets/30374a34-8811-48f9-a2d9-5b781635a4da" />
