### PR TITLE
Garbage cleanup

### DIFF
--- a/lua/ge/extensions/MPControllerGE.lua
+++ b/lua/ge/extensions/MPControllerGE.lua
@@ -21,7 +21,7 @@ local function sendControllerData(data, gameVehicleID)
 				decodedData.vehID = MPVehicleGE.getServerVehicleID(decodedData.vehID) -- used for controllers that call to another vehicle, like the me262 missile targeting system
 			end
 			data = jsonEncode(decodedData)
-			MPGameNetwork.send(MPHelpers.generatePacketBuffer('Rc',serverVehicleID,data))
+			MPGameNetwork.send(MPNetworkHelpers.generatePacketBuffer('Rc',serverVehicleID,data))
 		end
 	end
 end

--- a/lua/ge/extensions/MPControllerGE.lua
+++ b/lua/ge/extensions/MPControllerGE.lua
@@ -29,7 +29,7 @@ end
 
 local function applyControllerData(data, serverVehicleID)
 	local gameVehicleID = MPVehicleGE.getGameVehicleID(serverVehicleID) or -1
-	local veh = be:getObjectByID(gameVehicleID)
+	local veh = getObjectByID(gameVehicleID)
 	if veh then
 		local decodedData = jsonDecode(data)
 		if decodedData.vehID then

--- a/lua/ge/extensions/MPControllerGE.lua
+++ b/lua/ge/extensions/MPControllerGE.lua
@@ -21,8 +21,7 @@ local function sendControllerData(data, gameVehicleID)
 				decodedData.vehID = MPVehicleGE.getServerVehicleID(decodedData.vehID) -- used for controllers that call to another vehicle, like the me262 missile targeting system
 			end
 			data = jsonEncode(decodedData)
-			dump(data, gameVehicleID)
-			MPGameNetwork.send('Rc:'..serverVehicleID..":"..data)
+			MPGameNetwork.send(MPHelpers.generatePacketBuffer('Rc',serverVehicleID,data))
 		end
 	end
 end

--- a/lua/ge/extensions/MPControllerGE.lua
+++ b/lua/ge/extensions/MPControllerGE.lua
@@ -5,11 +5,9 @@
 local M = {}
 
 local function tick()
-	local ownMap = MPVehicleGE.getOwnMap() -- Get map of own vehicles
-	for i,v in pairs(ownMap) do -- For each own vehicle
-		local veh = be:getObjectByID(i) -- Get vehicle
-		if veh then
-			veh:queueLuaCommand("controllerSyncVE.getControllerData()") -- Send all devices values
+	for i,v in pairs(MPVehicleGE.getPlayerVehicleObjects(MPConfig.getPlayerServerID())) do
+		if v then
+			v:queueLuaCommand("controllerSyncVE.getControllerData()")
 		end
 	end
 end

--- a/lua/ge/extensions/MPCoreNetwork.lua
+++ b/lua/ge/extensions/MPCoreNetwork.lua
@@ -20,6 +20,8 @@ local TCPLauncherSocket = nop -- Launcher socket
 local socket = require('socket')
 local http = require("socket.http")
 local ltn12 = require("ltn12")
+local stringBuffer = require("string.buffer")
+local sendStringBuff = stringBuffer.new()
 local launcherConnected = false
 local isConnecting = false
 local proxyPort = ""
@@ -73,7 +75,8 @@ local function send(data) -- TODO currently the socket keeps retrying indefinite
 	if TCPLauncherSocket == nop then return end
 
 	local header = ffi.string(ffi.new("uint32_t[?]", 4, #data), 4)
-	local packet = header .. data
+	sendStringBuff:reset():put(header,data)
+	local packet = sendStringBuff:tostring()
 
 	local retries = 1
 

--- a/lua/ge/extensions/MPDebug.lua
+++ b/lua/ge/extensions/MPDebug.lua
@@ -15,7 +15,7 @@ local M = {}
 --- Teleports the players vehicle to a specified position.
 --- @param targetPos vec3 The target position to teleport the player to. Format: {x, y, z}
 local function tpPlayerToPos(targetPos)
-	local activeVehicle = be:getPlayerVehicle(0)
+	local activeVehicle = getPlayerVehicle(0)
 
 	if activeVehicle then
 

--- a/lua/ge/extensions/MPElectricsGE.lua
+++ b/lua/ge/extensions/MPElectricsGE.lua
@@ -35,7 +35,7 @@ local function sendElectrics(data, gameVehicleID)
 	if MPGameNetwork.launcherConnected() then
 		local serverVehicleID = MPVehicleGE.getServerVehicleID(gameVehicleID) -- Get serverVehicleID
 		if serverVehicleID and MPVehicleGE.isOwn(gameVehicleID) and data ~= lastElectrics then -- If serverVehicleID not null and player own vehicle
-			MPGameNetwork.send('We:'..serverVehicleID..":"..data)
+			MPGameNetwork.send(MPHelpers.generatePacketBuffer('We',serverVehicleID,data))
 			lastElectrics = data
 		end
 	end

--- a/lua/ge/extensions/MPElectricsGE.lua
+++ b/lua/ge/extensions/MPElectricsGE.lua
@@ -47,7 +47,7 @@ end
 -- @param serverVehicleID string The VehicleID according to the server.
 local function applyElectrics(data, serverVehicleID)
 	local gameVehicleID = MPVehicleGE.getGameVehicleID(serverVehicleID) or -1 -- get gameID
-	local veh = be:getObjectByID(gameVehicleID)
+	local veh = getObjectByID(gameVehicleID)
 	if veh then
 		if not MPVehicleGE.isOwn(gameVehicleID) then
 			veh:queueLuaCommand("MPElectricsVE.applyElectrics(mime.unb64(\'".. MPHelpers.b64encode(data) .."\'))")

--- a/lua/ge/extensions/MPElectricsGE.lua
+++ b/lua/ge/extensions/MPElectricsGE.lua
@@ -35,7 +35,7 @@ local function sendElectrics(data, gameVehicleID)
 	if MPGameNetwork.launcherConnected() then
 		local serverVehicleID = MPVehicleGE.getServerVehicleID(gameVehicleID) -- Get serverVehicleID
 		if serverVehicleID and MPVehicleGE.isOwn(gameVehicleID) and data ~= lastElectrics then -- If serverVehicleID not null and player own vehicle
-			MPGameNetwork.send(MPHelpers.generatePacketBuffer('We',serverVehicleID,data))
+			MPGameNetwork.send(MPNetworkHelpers.generatePacketBuffer('We',serverVehicleID,data))
 			lastElectrics = data
 		end
 	end

--- a/lua/ge/extensions/MPElectricsGE.lua
+++ b/lua/ge/extensions/MPElectricsGE.lua
@@ -17,12 +17,10 @@ local lastElectrics
 
 
 --- Called on specified interval by MPUpdatesGE to simulate our own tick event to collect data.
-local function tick() -- Update electrics values of all vehicles
-	local ownMap = MPVehicleGE.getOwnMap() -- Get map of own vehicles
-	for i,v in pairs(ownMap) do -- For each own vehicle
-		local veh = be:getObjectByID(i) -- Get vehicle
-		if veh then
-			veh:queueLuaCommand("MPElectricsVE.check()") -- Check if any value changed
+local function tick()
+	for i,v in pairs(MPVehicleGE.getPlayerVehicleObjects(MPConfig.getPlayerServerID())) do
+		if v then
+			v:queueLuaCommand("MPElectricsVE.check()")
 		end
 	end
 end

--- a/lua/ge/extensions/MPGameNetwork.lua
+++ b/lua/ge/extensions/MPGameNetwork.lua
@@ -446,7 +446,7 @@ end
 -- @tparam integer gameVehicleID - The ID of the game vehicle
 -- @usage MPGameNetwork.onVehicleReady(`<game vehicle id>`)
 local function onVehicleReady(gameVehicleID)
-	local veh = be:getObjectByID(gameVehicleID)
+	local veh = getObjectByID(gameVehicleID)
 	if not veh then
 		log('R', 'onVehicleReady', 'Vehicle does not exist!')
 		return

--- a/lua/ge/extensions/MPGameNetwork.lua
+++ b/lua/ge/extensions/MPGameNetwork.lua
@@ -291,7 +291,7 @@ end
 -- @tparam string data - The data to be sent with the event
 -- @usage TriggerServerEvent(`<name>`, `<data>`)
 function TriggerServerEvent(name, data)
-	M.send(MPHelpers.generatePacketBuffer('E',name,data))
+	M.send(MPNetworkHelpers.generatePacketBuffer('E',name,data))
 end
 
 --- Triggers a local client event with the specified name and data.

--- a/lua/ge/extensions/MPGameNetwork.lua
+++ b/lua/ge/extensions/MPGameNetwork.lua
@@ -291,7 +291,7 @@ end
 -- @tparam string data - The data to be sent with the event
 -- @usage TriggerServerEvent(`<name>`, `<data>`)
 function TriggerServerEvent(name, data)
-	M.send('E:'..name..':'..data)
+	M.send(MPHelpers.generatePacketBuffer('E',name,data))
 end
 
 --- Triggers a local client event with the specified name and data.
@@ -299,7 +299,7 @@ end
 -- @tparam string data - The data to be sent with the event
 -- @usage `TriggerClientEvent(`<name>`, `<data>`)
 function TriggerClientEvent(name, data)
-	handleEvents(':'..name..':'..data)
+	handleEvents(':'..name..':'..data) --TODO: make a string.match bypass
 end
 
 --- Adds an event handler for the specified event name and function.

--- a/lua/ge/extensions/MPGameNetwork.lua
+++ b/lua/ge/extensions/MPGameNetwork.lua
@@ -16,6 +16,8 @@ local ffi = require("ffi")
 -- ============= VARIABLES =============
 
 local socket = require('socket')
+local stringBuffer = require("string.buffer")
+local sendStringBuff = stringBuffer.new()
 local TCPLauncherSocket
 local launcherConnected = false
 local isConnecting = false
@@ -81,7 +83,8 @@ local function sendData(data) -- TODO currently the socket keeps retrying indefi
 	-- if not connected return
 	if not TCPLauncherSocket then return end
 	local header = ffi.string(ffi.new("uint32_t[?]", 4, #data), 4)
-	local packet = header .. data
+	sendStringBuff:reset():put(header,data)
+	local packet = sendStringBuff:tostring()
 
 	local retries = 1
 

--- a/lua/ge/extensions/MPHelpers.lua
+++ b/lua/ge/extensions/MPHelpers.lua
@@ -12,6 +12,9 @@ local M = {}
 local LOCALISATION = nil
 local mime = require'mime' -- Game libary. Used in BeamNG.drive\lua\common\libs\luasocket\socket\mime.lua. We only use it for b64
 
+local stringBuffer = require("string.buffer")
+local sendStringBuff = stringBuffer.new()
+
 setmetatable(_G,{}) -- temporarily disable global write notifications
 
 --- Returns the decoded lang table from disk
@@ -282,11 +285,24 @@ local function onExtensionLoaded()
 	M.translate                = MPTranslate
 end
 
+local function generatePacketBuffer(packetType,id,data)
+	sendStringBuff:reset()
+	sendStringBuff:put(packetType)
+	if id then
+		sendStringBuff:put(":",id)
+	end
+	if data then
+		sendStringBuff:put(":",data) -- delete packets doesn't include data
+	end
+	return sendStringBuff
+end
+
 M.b64encode                = b64encode
 M.b64decode                = b64decode
 M.getColorsFromVehObj      = getColorsFromVehObj
 M.splitStringToTable       = splitStringToTable
 M.simplifyVehConfig        = simplifyVehConfig
+M.generatePacketBuffer       = generatePacketBuffer
 
 M.onExtensionLoaded = onExtensionLoaded
 M.onInit = function() setExtensionUnloadMode(M, "manual") end

--- a/lua/ge/extensions/MPHelpers.lua
+++ b/lua/ge/extensions/MPHelpers.lua
@@ -285,24 +285,11 @@ local function onExtensionLoaded()
 	M.translate                = MPTranslate
 end
 
-local function generatePacketBuffer(packetType,id,data)
-	sendStringBuff:reset()
-	sendStringBuff:put(packetType)
-	if id then
-		sendStringBuff:put(":",id)
-	end
-	if data then
-		sendStringBuff:put(":",data) -- delete packets doesn't include data
-	end
-	return sendStringBuff
-end
-
 M.b64encode                = b64encode
 M.b64decode                = b64decode
 M.getColorsFromVehObj      = getColorsFromVehObj
 M.splitStringToTable       = splitStringToTable
 M.simplifyVehConfig        = simplifyVehConfig
-M.generatePacketBuffer       = generatePacketBuffer
 
 M.onExtensionLoaded = onExtensionLoaded
 M.onInit = function() setExtensionUnloadMode(M, "manual") end

--- a/lua/ge/extensions/MPHelpers.lua
+++ b/lua/ge/extensions/MPHelpers.lua
@@ -143,7 +143,7 @@ local function splitStringToTable(string, delimeter, convert_into)
 end
 
 --- Reads the vehicles color directly from the obj instead of from the vehicle_manager.lua
--- @param veh object Vehicle object from eg. be:getObjectByID(gameVehicleID)
+-- @param veh object Vehicle object from eg. getObjectByID(gameVehicleID)
 -- @return table paints Same format as extensions.core_vehicle_manager.getVehicleData(gameVehicleID).config.paints
 local function getColorsFromVehObj(veh)
 	local paints = {}

--- a/lua/ge/extensions/MPInputsGE.lua
+++ b/lua/ge/extensions/MPInputsGE.lua
@@ -42,7 +42,7 @@ end
 -- @param serverVehicleID string The VehicleID according to the server.
 local function applyInputs(data, serverVehicleID)
 	local gameVehicleID = MPVehicleGE.getGameVehicleID(serverVehicleID) or -1 -- get gameID
-	local veh = be:getObjectByID(gameVehicleID)
+	local veh = getObjectByID(gameVehicleID)
 	if veh then
 		veh:queueLuaCommand("MPInputsVE.applyInputs(mime.unb64(\'".. MPHelpers.b64encode(data) .."\'))")
 	end

--- a/lua/ge/extensions/MPInputsGE.lua
+++ b/lua/ge/extensions/MPInputsGE.lua
@@ -13,12 +13,10 @@ local M = {}
 
 
 --- Called on specified interval by MPUpdatesGE to simulate our own tick event to collect data.
-local function tick() -- Update inputs values of all vehicles - The server check if the player own the vehicle itself
-	local ownMap = MPVehicleGE.getOwnMap() or {} -- Get map of own vehicles
-	for i,v in pairs(ownMap) do -- For each own vehicle
-		local veh = be:getObjectByID(i) -- Get vehicle
-		if veh then
-			veh:queueLuaCommand("MPInputsVE.getInputs()") -- Send inputs values
+local function tick()
+	for i,v in pairs(MPVehicleGE.getPlayerVehicleObjects(MPConfig.getPlayerServerID())) do
+		if v then
+			v:queueLuaCommand("MPInputsVE.getInputs()")
 		end
 	end
 end

--- a/lua/ge/extensions/MPInputsGE.lua
+++ b/lua/ge/extensions/MPInputsGE.lua
@@ -31,7 +31,7 @@ local function sendInputs(data, gameVehicleID) -- Called by vehicle lua
 	if MPGameNetwork.launcherConnected() then
 		local serverVehicleID = MPVehicleGE.getServerVehicleID(gameVehicleID) -- Get serverVehicleID
 		if serverVehicleID and MPVehicleGE.isOwn(gameVehicleID) then -- If serverVehicleID not null and player own vehicle
-			MPGameNetwork.send('Vi:'..serverVehicleID..":"..data)--Network.buildPacket(0, 2130, serverVehicleID, data))
+			MPGameNetwork.send(MPHelpers.generatePacketBuffer('Vi',serverVehicleID,data))
 		end
 	end
 end

--- a/lua/ge/extensions/MPInputsGE.lua
+++ b/lua/ge/extensions/MPInputsGE.lua
@@ -31,7 +31,7 @@ local function sendInputs(data, gameVehicleID) -- Called by vehicle lua
 	if MPGameNetwork.launcherConnected() then
 		local serverVehicleID = MPVehicleGE.getServerVehicleID(gameVehicleID) -- Get serverVehicleID
 		if serverVehicleID and MPVehicleGE.isOwn(gameVehicleID) then -- If serverVehicleID not null and player own vehicle
-			MPGameNetwork.send(MPHelpers.generatePacketBuffer('Vi',serverVehicleID,data))
+			MPGameNetwork.send(MPNetworkHelpers.generatePacketBuffer('Vi',serverVehicleID,data))
 		end
 	end
 end

--- a/lua/ge/extensions/MPNetworkHelpers.lua
+++ b/lua/ge/extensions/MPNetworkHelpers.lua
@@ -1,5 +1,8 @@
 local M = {}
 
+local stringBuffer = require("string.buffer")
+local sendStringBuff = stringBuffer.new()
+
 local ffi = require("ffi")
 
 --- Receives a packet from the launcher, prefixed with a 4-byte binary header. Handles errors and partial receives.
@@ -88,5 +91,19 @@ M.receive = function(launcherSocket, recvState)
 	end
 	return recvState
 end
+
+local function generatePacketBuffer(packetType,serverVehicleID,data)
+	sendStringBuff:reset()
+	sendStringBuff:put(packetType)
+	if serverVehicleID then
+		sendStringBuff:put(":",serverVehicleID)
+	end
+	if data then
+		sendStringBuff:put(":",data) -- delete packets doesn't include data
+	end
+	return sendStringBuff
+end
+
+M.generatePacketBuffer = generatePacketBuffer
 
 return M

--- a/lua/ge/extensions/MPPowertrainGE.lua
+++ b/lua/ge/extensions/MPPowertrainGE.lua
@@ -30,7 +30,7 @@ local function sendLivePowertrain(data, gameVehicleID)
 	if MPGameNetwork.launcherConnected() then
 		local serverVehicleID = MPVehicleGE.getServerVehicleID(gameVehicleID) -- Get serverVehicleID
 		if serverVehicleID and MPVehicleGE.isOwn(gameVehicleID) then -- If serverVehicleID not null and player own vehicle
-			MPGameNetwork.send('Yl:'..serverVehicleID..":"..data) -- Send powertrain to server
+			MPGameNetwork.send(MPHelpers.generatePacketBuffer('Yl',serverVehicleID,data))
 		end
 	end
 end
@@ -52,7 +52,7 @@ local function sendEngineData(data, gameVehicleID)
 	if MPGameNetwork.launcherConnected() then
 		local serverVehicleID = MPVehicleGE.getServerVehicleID(gameVehicleID) -- Get serverVehicleID
 		if serverVehicleID and MPVehicleGE.isOwn(gameVehicleID) then -- If serverVehicleID not null and player own vehicle
-			MPGameNetwork.send('Ye:'..serverVehicleID..":"..data) -- Send powertrain to server
+			MPGameNetwork.send(MPHelpers.generatePacketBuffer('Ye',serverVehicleID,data))
 		end
 	end
 end

--- a/lua/ge/extensions/MPPowertrainGE.lua
+++ b/lua/ge/extensions/MPPowertrainGE.lua
@@ -41,7 +41,7 @@ end
 -- @param serverVehicleID string The VehicleID according to the server.
 local function applyLivePowertrain(data, serverVehicleID)
 	local gameVehicleID = MPVehicleGE.getGameVehicleID(serverVehicleID) or -1 -- get gameID
-	local veh = be:getObjectByID(gameVehicleID)
+	local veh = getObjectByID(gameVehicleID)
 	if veh then
 		veh:queueLuaCommand("MPPowertrainVE.applyLivePowertrain(mime.unb64(\'".. MPHelpers.b64encode(data) .."\'))")
 	end
@@ -60,7 +60,7 @@ end
 
 local function applyEngineData(data, serverVehicleID)
 	local gameVehicleID = MPVehicleGE.getGameVehicleID(serverVehicleID) or -1 -- get gameID
-	local veh = be:getObjectByID(gameVehicleID)
+	local veh = getObjectByID(gameVehicleID)
 	if veh then
 		veh:queueLuaCommand("MPPowertrainVE.applyEngineData(mime.unb64(\'".. MPHelpers.b64encode(data) .."\'))")
 	end

--- a/lua/ge/extensions/MPPowertrainGE.lua
+++ b/lua/ge/extensions/MPPowertrainGE.lua
@@ -30,7 +30,7 @@ local function sendLivePowertrain(data, gameVehicleID)
 	if MPGameNetwork.launcherConnected() then
 		local serverVehicleID = MPVehicleGE.getServerVehicleID(gameVehicleID) -- Get serverVehicleID
 		if serverVehicleID and MPVehicleGE.isOwn(gameVehicleID) then -- If serverVehicleID not null and player own vehicle
-			MPGameNetwork.send(MPHelpers.generatePacketBuffer('Yl',serverVehicleID,data))
+			MPGameNetwork.send(MPNetworkHelpers.generatePacketBuffer('Yl',serverVehicleID,data))
 		end
 	end
 end
@@ -52,7 +52,7 @@ local function sendEngineData(data, gameVehicleID)
 	if MPGameNetwork.launcherConnected() then
 		local serverVehicleID = MPVehicleGE.getServerVehicleID(gameVehicleID) -- Get serverVehicleID
 		if serverVehicleID and MPVehicleGE.isOwn(gameVehicleID) then -- If serverVehicleID not null and player own vehicle
-			MPGameNetwork.send(MPHelpers.generatePacketBuffer('Ye',serverVehicleID,data))
+			MPGameNetwork.send(MPNetworkHelpers.generatePacketBuffer('Ye',serverVehicleID,data))
 		end
 	end
 end

--- a/lua/ge/extensions/MPPowertrainGE.lua
+++ b/lua/ge/extensions/MPPowertrainGE.lua
@@ -14,11 +14,9 @@ local M = {}
 
 --- Called on specified interval by MPUpdatesGE to simulate our own tick event to collect data.
 local function tick()
-	local ownMap = MPVehicleGE.getOwnMap() -- Get map of own vehicles
-	for i,v in pairs(ownMap) do -- For each own vehicle
-		local veh = be:getObjectByID(i) -- Get vehicle
-		if veh then
-			veh:queueLuaCommand("MPPowertrainVE.check()") -- Send all devices values
+	for i,v in pairs(MPVehicleGE.getPlayerVehicleObjects(MPConfig.getPlayerServerID())) do
+		if v then
+			v:queueLuaCommand("MPPowertrainVE.check()")
 		end
 	end
 end

--- a/lua/ge/extensions/MPUpdatesGE.lua
+++ b/lua/ge/extensions/MPUpdatesGE.lua
@@ -46,6 +46,7 @@ end
 -- @param dt float
 local function onUpdate(dt)
 	if MPGameNetwork and MPGameNetwork.launcherConnected() then
+		if be:getObjectCount() == 0 then return end
 		nodesTimer = nodesTimer + dt
 		if nodesTimer >= nodesTickrate then
 			nodesTimer = (nodesTimer - nodesTickrate) % nodesTickrate

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -996,22 +996,31 @@ function Player:addVehicle(v)
 		self.vehicles.objects[id] = getObjectByID(getGameVehicleID(id)) or nil
 	end
 	log('W', 'Player:addVehicle', 'Assigned vehicle ID '..tostring(id)..' to player '..self.name)
+	local veh = vehicles[id]
+	if veh then
+		veh:updateNameTagCache()
+		veh:updateSpectatorsTagCache()
+	end
 end
 function Player:setNickPrefix(tagSource, text)
 	--setPlayerNickPrefix(self.name, tagSource, text)
 	if text == nil then text = tagSource; tagSource = "default" end
 	self.nickPrefixes[tagSource] = text
+	self:updateNameTagCache()
 end
 function Player:setNickSuffix(tagSource, text)
 	--setPlayerNickSuffix(self.name, tagSource, text)
 	if text == nil then text = tagSource; tagSource = "default" end
 	self.nickSuffixes[tagSource] = text
+	self:updateNameTagCache()
 end
 function Player:setCustomRole(role)
 	self.customRole = role
+	self:updateNameTagCache()
 end
 function Player:clearCustomRole(roleName)
 	self.customRole = nil
+	self:updateNameTagCache()
 end
 function Player:delete()
 	log('W', 'Player:delete', string.format('Removing player %s (%i)! Data: %s', self.name, self.playerID, dumps(self)))
@@ -1022,6 +1031,22 @@ function Player:delete()
 	players[self.playerID] = nil
 
 	self = nil
+end
+function Player:updateNameTagCache()
+	for id,id in pairs(self.vehicles.IDs) do
+		local veh = vehicles[id]
+		if veh then
+			veh:updateNameTagCache()
+		end
+	end
+end
+function Player:updateSpectatorsTagCache()
+	for id,id in pairs(self.vehicles.IDs) do
+		local veh = vehicles[id]
+		if veh then
+			veh:updateSpectatorsTagCache()
+		end
+	end
 end
 function Player:onSerialized()
 	local t = {
@@ -1037,6 +1062,8 @@ function Player:onSettingsChanged()
 	local charLimit = tonumber(settings.getValue("nametagCharLimit"))
 	if not settings.getValue("shortenNametags") or not charLimit or #self.name <= charLimit + 3 then
 		self.shortname = self.name
+		self:updateNameTagCache()
+		self:updateSpectatorsTagCache()
 		return
 	end
 
@@ -1044,6 +1071,8 @@ function Player:onSettingsChanged()
 	if #short ~= #self.name then short = short .. "..." end
 
 	self.shortname = short
+	self:updateNameTagCache()
+	self:updateSpectatorsTagCache()
 end
 
 local Vehicle = {}
@@ -1075,6 +1104,7 @@ function Vehicle:new(data)
 	end
 
 	o.ownerName = data.ownerName
+	o.nameTag = data.ownerName
 	o.isLocal = data.isLocal or false
 	o.isSpawned = data.isSpawned ~= false -- default to true
 	o.isDeleted = data.isDeleted or false
@@ -1083,6 +1113,7 @@ function Vehicle:new(data)
 	o.rotation = quat()
 
 	o.spectators = {}
+	o.spectatorsTag = ""
 
 	if not settings.getValue("showDebugOutput") then
 		log('W', 'Vehicle:new', string.format("Vehicle %s (%s) created! Data:%s", o.serverVehicleString, o.ownerName, dumps(data)))
@@ -1106,12 +1137,54 @@ function Vehicle:delete()
 end
 function Vehicle:setCustomRole(role)
 	self.customRole = role
+	self:updateNameTagCache()
+	self:updateSpectatorsTagCache() --TODO: find out if this is necessary
 end
 function Vehicle:clearCustomRole(roleName)
 	self.customRole = nil
+	self:updateNameTagCache()
+	self:updateSpectatorsTagCache() --TODO: find out if this is necessary
 end
 function Vehicle:setDisplayName(displayName)
 	self.customName = displayName
+	self:updateNameTagCache()
+	self:updateSpectatorsTagCache() --TODO: find out if this is necessary
+end
+function Vehicle:updateNameTagCache()
+	local owner = self:getOwner()
+	local roleInfo = self.customRole or owner.customRole or owner.role
+
+	local ownerName = settings.getValue("shortenNametags") and owner.shortname or owner.name
+	local name = self.customName or ownerName
+
+	local tag = settings.getValue("shortenNametags") and roleInfo.shorttag or roleInfo.tag
+	local prefix = ""
+	for source, tag in pairs(owner.nickPrefixes) do
+		prefix = prefix..tag.." "
+	end
+
+	local suffix = ""
+	for source, tag in pairs(owner.nickSuffixes) do
+		suffix = suffix..tag.." "
+	end
+	self.nameTag = String(" " .. table.concat({prefix, name, suffix, tag}) .. " ")
+end
+function Vehicle:updateSpectatorsTagCache()
+	local owner = self:getOwner()
+	local spectators = ""
+	for spectatorID, _ in pairs(self.spectators) do
+		local spectator = players[spectatorID]
+		if not (spectator == owner or spectator.isLocal) then
+			local spectatorName = settings.getValue("shortenNametags") and spectator.shortname or spectator.name
+			spectators = spectators .. spectatorName .. ', '
+		end
+	end
+	if spectators ~= "" then
+		spectators = spectators:sub(1,-3) -- cut off tailing comma
+		self.spectatorsTag = String(" ".. spectators .." ")
+	else
+		self.spectatorsTag = ""
+	end
 end
 function Vehicle:onSerialized()
 	local t = {
@@ -1977,14 +2050,19 @@ end
 
 local function onServerCameraSwitched(playerID, serverVehicleID)
 	if not players[playerID] then return end -- TODO: better fix?
-	if players[playerID] and players[playerID].activeVehicleID and vehicles[players[playerID].activeVehicleID] then
-		vehicles[players[playerID].activeVehicleID].spectators[playerID] = nil -- clear prev spectator field
+	if players[playerID] and players[playerID].activeVehicleID then
+		local veh = vehicles[players[playerID].activeVehicleID]
+		if veh then
+			vehicles[players[playerID].activeVehicleID].spectators[playerID] = nil -- clear prev spectator field
+			veh:updateSpectatorsTagCache()
+		end
 	end
 
 	players[playerID].activeVehicleID = serverVehicleID
 
 	if not vehicles[serverVehicleID] then return end
 	vehicles[serverVehicleID].spectators[playerID] = true
+	vehicles[serverVehicleID]:updateSpectatorsTagCache()
 end
 
 local function onServerVehicleColorChanged(serverVehicleID, data)
@@ -2576,43 +2654,17 @@ local function onPreRender(dt)
 
 
 				local roleInfo = v.customRole or owner.customRole or owner.role
-
-				local ownerName = settings.getValue("shortenNametags") and owner.shortname or owner.name
-				local name = v.customName or ownerName
-
-				local tag = settings.getValue("shortenNametags") and roleInfo.shorttag or roleInfo.tag
 				local backColor = color(roleInfo.backcolor.r, roleInfo.backcolor.g, roleInfo.backcolor.b, math.floor(nametagAlpha*127))
-
-				local prefix = ""
-				for source, tag in pairs(owner.nickPrefixes)
-					do prefix = prefix..tag.." " end
-
-				local suffix = ""
-				for source, tag in pairs(owner.nickSuffixes)
-					do suffix = suffix..tag.." " end
-
-
 				-- draw spectators
 				if settings.getValue("showSpectators") then
-					local spectators = ""
-
-					for spectatorID, _ in pairs(v.spectators) do
-						local spectator = players[spectatorID]
-						if not (spectator == owner or spectator.isLocal) then
-							spectators = spectators .. spectator.name .. ', '
-						end
-					end
-
-					spectators = spectators:sub(1,-3) -- cut off tailing comma
-
-					if spectators ~= "" then
+					if v.spectatorsTag ~= "" then
 						local spectatorBackColor = backColor
 						if settings.getValue("spectatorUnifiedColors") then
 							spectatorBackColor = color(roleToInfo.USER.backcolor.r, roleToInfo.USER.backcolor.g, roleToInfo.USER.backcolor.b, math.floor(nametagAlpha*127))
 						end
 						drawTextAdvanced(
 							pos.x, pos.y, pos.z, -- Location
-							String(" ".. spectators .." "), -- Text
+							v.spectatorsTag, -- Text
 							color(255, 255, 255, nametagAlpha*254), -- Foreground Color, Alpha is multiplied by 254 because using 255 seems to break backround alpha in 0.37
 							true, -- Draw background 
 							false, -- Wtf
@@ -2627,7 +2679,7 @@ local function onPreRender(dt)
 				-- draw main nametag
 				drawTextAdvanced(
 					pos.x, pos.y, pos.z, -- Location
-					String(" " .. table.concat({prefix, name, suffix, tag, dist}) .. " "), -- Text
+					v.nameTag .. dist, -- Text
 					color(255, 255, 255, nametagAlpha*254), -- Foreground Color, Alpha is multiplied by 254 because using 255 seems to break backround alpha in 0.37
 					true, -- Draw background 
 					false, -- Wtf

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -2774,6 +2774,10 @@ local function onVehicleReady(gameVehicleID)
 	if veh.mpVehicleType then
 		veh:queueLuaCommand("MPVehicleVE.setVehicleType(mime.unb64(\'".. MPHelpers.b64encode(veh.mpVehicleType) .."\'))")
 	end
+	if vehiclesMap[gameVehicleID] then
+		veh:queueLuaCommand("MPVehicleVE.setServerID(mime.unb64(\'".. MPHelpers.b64encode(vehiclesMap[gameVehicleID]) .."\'))")
+	end
+
 	MPGameNetwork.onVehicleReady(gameVehicleID)
 end
 

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1248,7 +1248,7 @@ end
 --called by onVehicleSpawned
 --============================ SEND VEHICLE ============================
 local function sendVehicleSpawn(gameVehicleID)
-	local veh = be:getObjectByID(gameVehicleID) -- Get spawned vehicle ID
+	local veh = getObjectByID(gameVehicleID) -- Get spawned vehicle ID
 	if veh then -- In case of bug
 		local vehicleTable = {}
 		local vehicleData  = extensions.core_vehicle_manager.getVehicleData(gameVehicleID)
@@ -1297,7 +1297,7 @@ end
 local function sendVehicleEdit(gameVehicleID)
 	local vehicleTable = {} -- Vehicle table
 	local vehicleData  = extensions.core_vehicle_manager.getVehicleData(gameVehicleID)
-	local veh          = be:getObjectByID(gameVehicleID)
+	local veh          = getObjectByID(gameVehicleID)
 	local c            = veh.color
 	local p0           = veh.colorPalette0
 	local p1           = veh.colorPalette1
@@ -1336,7 +1336,7 @@ end
 -- Patch Game Functions in relation to vehicle configs
 local core_vehicles_cloneCurrent = core_vehicles.cloneCurrent
 core_vehicles.cloneCurrent = function ()
-	local vehicle = be:getPlayerVehicle(0)
+	local vehicle = getPlayerVehicle(0)
 	if vehicle:getField("protected", 0) == "1" then
 		local title = MPTranslate("ui.beammp.configprotection.clone.title", "Vehicle Clone Error")
 		local msg = MPTranslate("ui.beammp.configprotection.clone.message", "Sorry, you cannot clone this vehicle.")
@@ -1349,7 +1349,7 @@ end
 
 local core_vehicle_partmgmt_saveLocal = extensions.core_vehicle_partmgmt.saveLocal
 local function core_vehicle_partmgmt_saveLocal_overwrite(p1)
-	local vehicle = be:getPlayerVehicle(0)
+	local vehicle = getPlayerVehicle(0)
 	if vehicle:getField("protected", 0) == "1" then
 		local title = MPTranslate("ui.beammp.configprotection.save.title", "Vehicle Save Error")
 		local msg = MPTranslate("ui.beammp.configprotection.save.message", "Sorry, you cannot save this vehicle.")
@@ -1362,7 +1362,7 @@ end
 
 local core_vehicle_partmgmnt_savedefault = extensions.core_vehicle_partmgmt.savedefault
 local function core_vehicle_partmgmnt_savedefault_overwrite(p1)
-	local vehicle = be:getPlayerVehicle(0)
+	local vehicle = getPlayerVehicle(0)
 	if vehicle:getField("protected", 0) == "1" then
 		local title = MPTranslate("ui.beammp.configprotection.save.title", "Vehicle Save Error")
 		local msg = MPTranslate("ui.beammp.configprotection.save.message", "Sorry, you cannot save this vehicle.")
@@ -1439,7 +1439,7 @@ local function applyVehSpawn(event)
 	end
 
 	local spawnedVehID = getGameVehicleID(event.serverVehicleID)
-	local spawnedVeh = spawnedVehID and be:getObjectByID(spawnedVehID) or nil
+	local spawnedVeh = spawnedVehID and getObjectByID(spawnedVehID) or nil
 
 	if spawnedVeh then -- if a vehicle with this ID was found update the obj
 		log('W', 'applyVehSpawn', "(spawn)Updating vehicle from server "..vehicleName.." with id "..spawnedVehID)
@@ -1483,7 +1483,7 @@ local function applyVehEdit(serverID, data)
 	local gameVehicleID = getGameVehicleID(serverID) -- Get the gameVehicleID
 	if not gameVehicleID then log('E','applyVehEdit',"gameVehicleID for "..serverID.." not found") return end
 
-	local veh = be:getObjectByID(gameVehicleID) -- Get the vehicle
+	local veh = getObjectByID(gameVehicleID) -- Get the vehicle
 	if not veh then log('E','applyVehEdit',"Vehicle "..gameVehicleID.." not found") return end
 
 	local decodedData   = jsonDecode(data) -- Decode the data
@@ -1514,7 +1514,7 @@ local function applyVehEdit(serverID, data)
 			tableMerge(playerVehicle.config, vehicleConfig) -- add new parts to the existing config
 
 			if configChanged then
-				veh:setDynDataFieldbyName("autoEnterVehicle", 0, tostring((be:getPlayerVehicle(0) and be:getPlayerVehicle(0):getID() == gameVehicleID) or false))
+				veh:setDynDataFieldbyName("autoEnterVehicle", 0, tostring((getPlayerVehicle(0) and getPlayerVehicle(0):getID() == gameVehicleID) or false))
 				veh:respawn(serialize(playerVehicle.config))
 				if settings.getValue("licensePlateUsesPlayerName") then
 					core_vehicles.setPlateText(data.playerNickname, gameVehicleID)
@@ -1537,7 +1537,7 @@ local function applyVehEdit(serverID, data)
 			pos = veh:getPosition(), rot = quat(0,0,1,0) *  quatFromDir(-vec3(veh:getDirectionVector()), vec3(veh:getDirectionVectorUp())), cling = true,
 		}
 
-		veh:setDynDataFieldbyName("autoEnterVehicle", 0, tostring((be:getPlayerVehicle(0) and be:getPlayerVehicle(0):getID() == gameVehicleID) or false))
+		veh:setDynDataFieldbyName("autoEnterVehicle", 0, tostring((getPlayerVehicle(0) and getPlayerVehicle(0):getID() == gameVehicleID) or false))
 		log('I', 'applyVehEdit', "Updating vehicle from server "..vehicleName.." with id "..serverID)
 		spawn.setVehicleObject(veh, options)
 
@@ -1559,7 +1559,7 @@ local function onVehicleSpawned(gameVehicleID)
 
 	if not MPCoreNetwork.isMPSession() then return end -- do nothing if singleplayer
 
-	local veh = be:getObjectByID(gameVehicleID)
+	local veh = getObjectByID(gameVehicleID)
 	local newJbeamName = veh:getJBeamFilename()
 
 	local vehicle = getVehicleByGameID(gameVehicleID)
@@ -1675,7 +1675,7 @@ local function onVehicleDestroyed(gameVehicleID)
 			log('I', "onVehicleDestroyed", string.format("Vehicle %i (%s) removed by local player", gameVehicleID, serverVehicleID or "?"))
 			if vehicle.isLocal then
 				if serverVehicleID then
-					local veh = be:getObjectByID(gameVehicleID)
+					local veh = getObjectByID(gameVehicleID)
 					if veh and veh:getJBeamFilename() == "unicycle" and settings.getValue("unicycleAutoSave") == true then -- if the player destroyed their unicycle
 						local vehicleConfig = extensions.core_vehicle_manager.getVehicleData(gameVehicleID).config
 						--[[ Contains as of 0.30
@@ -1809,7 +1809,7 @@ local function onVehicleResetted(gameVehicleID)
 		local vehicle = getVehicleByGameID(gameVehicleID)
 		if vehicle and vehicle.serverVehicleString and vehicle.isLocal then -- If serverVehicleID not null and player own vehicle -- If it's not null
 			--print("Vehicle "..gameVehicleID.." resetted by client")
-			local veh = be:getObjectByID(gameVehicleID)
+			local veh = getObjectByID(gameVehicleID)
 			local pos = veh:getPosition()
 			local rot = quatFromDir(-vec3(veh:getDirectionVector()), vec3(veh:getDirectionVectorUp()))
 			local tempTable = {
@@ -1843,7 +1843,7 @@ local function onVehicleColorChanged(gameVehicleID, index, paint)
     local vehicle = getVehicleByGameID(gameVehicleID) -- get vehicle table for this vehicle
     if vehicle and vehicle.serverVehicleString and vehicle.isLocal then -- If serverVehicleID not null and player own vehicle
 
-        local veh = be:getObjectByID(gameVehicleID) -- get vehicle as object
+        local veh = getObjectByID(gameVehicleID) -- get vehicle as object
 		local paintData =  MPHelpers.getColorsFromVehObj(veh)
         paintData[index] = paint --insert new paint at index as chosen from color picker
 
@@ -1892,7 +1892,7 @@ local function onServerVehicleSpawned(playerRole, playerNickname, serverVehicleI
 
 		log("W", "onServerVehicleSpawned", "ID is same as received ID, synced vehicle gameVehicleID: "..gameVehicleID.." with ServerID: "..serverVehicleID)
 		
-		local veh = be:getObjectByID(gameVehicleID)
+		local veh = getObjectByID(gameVehicleID)
 		if not veh or not veh:getActive() then
 			log("W", "onServerVehicleSpawned", "Local vehicle "..gameVehicleID.." does not exist anymore, triggering delete event for server vehicle "..serverVehicleID)
 			onVehicleDestroyed(gameVehicleID)
@@ -1968,7 +1968,7 @@ local function onServerVehicleEdited(serverID, data)
 		UI.updateQueue(getQueueCounts())
 		UI.showNotification('Edit received and queued for '..playerNickname, ''..playerNickname..''..serverID..'edit', 'build')
 	else
-		local currentVeh = be:getPlayerVehicle(0) -- Camera fix
+		local currentVeh = getPlayerVehicle(0) -- Camera fix
 
 		applyVehEdit(serverID, data)
 		UI.updateQueue(0, 0)
@@ -1995,10 +1995,10 @@ local function onServerVehicleRemoved(serverVehicleID)
 	local gameVehicleID = vehicle.gameVehicleID
 	if gameVehicleID > 0 then
 		log('I', "onServerVehicleRemoved", string.format("Vehicle %i (%s) removed by server ", gameVehicleID, serverVehicleID))
-		local veh = be:getObjectByID(gameVehicleID) -- Get associated vehicle
+		local veh = getObjectByID(gameVehicleID) -- Get associated vehicle
 		if veh then
 			onVehicleDestroyedAllowed = false
-			local currveh = be:getPlayerVehicle(0)
+			local currveh = getPlayerVehicle(0)
 			local isCurrent = (currveh and currveh:getID() == gameVehicleID) or false
 			veh:delete() -- Remove it
 			if isCurrent then be:enterNextVehicle(0,1) end-- Fix camera
@@ -2019,7 +2019,7 @@ local function onServerVehicleResetted(serverVehicleID, data)
 	local gameVehicleID = getGameVehicleID(serverVehicleID) -- Get game ID
 	if localCounter - (lastResetTime[serverVehicleID] or 0) > 0.2 then
 		if gameVehicleID then
-			local veh = be:getObjectByID(gameVehicleID) -- Get associated vehicle
+			local veh = getObjectByID(gameVehicleID) -- Get associated vehicle
 			if veh then
 				local pr = jsonDecode(data) -- Decoded data
 				veh:queueLuaCommand("extensions.hook(\"onBeamMPVehicleReset\")")
@@ -2041,7 +2041,7 @@ end
 local function onServerVehicleCoupled(serverVehicleID, data)
 	local vehicle = getVehicleByServerID(serverVehicleID) -- Get game ID
 	if not vehicle.isLocal then
-		local veh = be:getObjectByID(vehicle.gameVehicleID)
+		local veh = getObjectByID(vehicle.gameVehicleID)
 		if veh then
 			veh:queueLuaCommand("couplerVE.toggleCouplerState(mime.unb64(\'".. MPHelpers.b64encode(data) .."\'))")
 		end
@@ -2071,7 +2071,7 @@ local function onServerVehicleColorChanged(serverVehicleID, data)
 
     if vehicle and vehicle.serverVehicleString and not vehicle.isLocal then -- If serverVehicleID not null and not player own vehicle
         if gameVehicleID and gameVehicleID ~= -1 and not vehicle.editQueue then
-            local veh = be:getObjectByID(gameVehicleID) -- Get associated vehicle
+            local veh = getObjectByID(gameVehicleID) -- Get associated vehicle
             if veh then
                 local paint = jsonDecode(data) -- Decoded data
                 if paint then -- if there's paint data
@@ -2183,7 +2183,7 @@ local function handle(rawData)
 end
 
 local function saveDefaultRequest()
-	local currentVehicle = be:getPlayerVehicle(0)
+	local currentVehicle = getPlayerVehicle(0)
 	if not MPCoreNetwork.isMPSession() or currentVehicle and isOwn(currentVehicle:getID()) then
 		extensions.core_vehicle_partmgmt.savedefault()
 		log('I', "saveDefaultRequest", "Request to save vehicle accepted")
@@ -2196,7 +2196,7 @@ end
 local function spawnDefaultRequest()
 	if not MPCoreNetwork.isMPSession() then original_spawnDefault(); extensions.hook("onBeamMPTrackNewVehicle"); return end
 
-	local currentVehicle = be:getPlayerVehicle(0)
+	local currentVehicle = getPlayerVehicle(0)
 	local defaultConfig = jsonReadFile('settings/default.pc')
 
 	if currentVehicle then
@@ -2219,7 +2219,7 @@ local function spawnRequest(model, config, colors)
 end
 
 local function replaceRequest(model, config, colors)
-	local currentVehicle = be:getPlayerVehicle(0)
+	local currentVehicle = getPlayerVehicle(0)
 	local gameVehicleID = currentVehicle and currentVehicle:getID() or -1
 	local vehicle = getVehicleByGameID(gameVehicleID)
 
@@ -2759,7 +2759,7 @@ end
 
 local function onVehicleReady(gameVehicleID)
 	log('M', 'onVehicleReady', 'Vehicle '..tostring(gameVehicleID)..' signaled that it is ready')
-	local veh = be:getObjectByID(gameVehicleID)
+	local veh = getObjectByID(gameVehicleID)
 	if not veh then
 		log('E', 'onVehicleReady', 'Vehicle does not exist!')
 		return

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -2612,28 +2612,25 @@ local function onPreRender(dt)
 
 				local dist = ""
 				if distfloat > 10 and settings.getValue("nameTagShowDistance") then
-					local unit
 					local mapEntry = distfloat
 					if settings.getValue("uiUnitLength") == "imperial" then
 						mapEntry = mapEntry * 3.28084
 						if mapEntry > 5280 then
 							mapEntry = math.floor((mapEntry / 5280 * 100) + 0.5) / 100
-							unit = "mi"
+							dist = string.format("%.2f mi ", mapEntry)
 						else
 							mapEntry = math.floor(mapEntry)
-							unit = "ft"
+							dist = string.format("%.f ft ", mapEntry)
 						end
 					else
 						if mapEntry >= 1000 then
 							mapEntry = math.floor((mapEntry / 10) + 0.5) / 100
-							unit = "km"
+							dist = string.format("%.2f km ", mapEntry)
 						else
 							mapEntry = math.floor(mapEntry)
-							unit = "m"
+							dist = string.format("%.f m ", mapEntry)
 						end
 					end
-
-					dist = string.format(" %s %s", tostring(mapEntry), unit)
 				end
 
 				if settings.getValue("fadeVehicles") and veh then

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -51,6 +51,14 @@ local original_spawnNewVehicle
 local original_replaceVehicle
 local original_spawnDefault
 
+-- ============= vector cache  =============
+local cameraPos = vec3()
+local pos = vec3()
+local dir = vec3()
+local dirUp = vec3()
+local activeVehPos = vec3()
+local vehVel = vec3()
+
 local ffiFound = false
 if ffi and ffi.C then
 	ffiFound = true
@@ -1069,8 +1077,8 @@ function Vehicle:new(data)
 	o.isSpawned = data.isSpawned ~= false -- default to true
 	o.isDeleted = data.isDeleted or false
 
-	o.position = nil
-	o.rotation = nil
+	o.position = vec3()
+	o.rotation = quat()
 
 	o.spectators = {}
 
@@ -1339,7 +1347,7 @@ local function applyVehSpawn(event)
 	
 
 	local vehicle = vehicles[event.serverVehicleID]
-	if vehicle and vehicle.position and vehicle.rotation then -- if we have receieved position packets then use that for position and rotation instead
+	if vehicle and vehicle.position and vehicle.position:squaredLength() ~= 0 and vehicle.rotation then -- if we have receieved position packets then use that for position and rotation instead
 		pos = vec3(vehicle.position)
 		rot = quat(0,0,1,0) * quat(vehicle.rotation) -- the car rotates 180 degrees on spawn so we need to counter that
 	end
@@ -2414,20 +2422,26 @@ local function onPreRender(dt)
 			if v.isLocal or not owner then goto skip_vehicle end
 			local gameVehicleID = v.gameVehicleID
 			local veh = be:getObjectByID(gameVehicleID)
+			local heightOffset = 0
 
 			if v.isSpawned and veh then -- update position if available
 				if not v.vehicleHeight or v.vehicleHeight == 0 then
 					v.vehicleHeight = veh:getInitialHeight()
 				end
-				local tempPosx,tempPosy,tempPosz = be:getObjectOOBBCenterXYZ(gameVehicleID)
-				v.position = vec3(tempPosx,tempPosy,tempPosz)
-				v.position.z = v.position.z + (v.vehicleHeight * 0.5) + 0.2
+				v.position:set(be:getObjectOOBBCenterXYZ(gameVehicleID))
+				heightOffset = (v.vehicleHeight * 0.5) + 0.2
 
-				v.rotation = quatFromDir(-vec3(veh:getDirectionVector()), vec3(veh:getDirectionVectorUp())) -- getRotation doesn't update in GE so we need to use direction vectors instead
+				--updating rotations, it uses vectors due to getRotation not being updated
+				--using set functions with XYZ like this is garbage free
+				dir:set(veh:getDirectionVectorXYZ())
+				dirUp:set(veh:getDirectionVectorUpXYZ())
+				v.rotation:setFromDir(dir,dirUp)
 			end
 
 			if not v.position then goto skip_vehicle end -- return if no position has been received yet
-			local pos = Point3F(v.position.x, v.position.y, v.position.z)
+
+			pos:set(v.position)
+			pos.z = pos.z + heightOffset
 
 			if settings.getValue("enableBlobs") and not v.isSpawned then
 				local colors = nil

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -412,6 +412,18 @@ local function createRoleHelper(tag, shorttag, red, green, blue)
 	return contents
 end
 
+local function getPlayerVehicles(playerID)
+	return players[playerID] and players[playerID].vehicles or {IDs = {}, objects = {}}
+end
+
+local function getPlayerVehicleIDs(playerID)
+	return players[playerID] and players[playerID].vehicles.IDs or {}
+end
+
+local function getPlayerVehicleObjects(playerID)
+	return players[playerID] and players[playerID].vehicles.objects or {}
+end
+
 --- Sets a custom role for a player
 -- @tparam int playerID ID of the player
 -- @tparam string tag normal version of the role tag
@@ -927,7 +939,7 @@ function Player:new(data)
 
 	o.customRole = nil
 
-	o.vehicles = {IDs = data.vehicleIDs or {}}
+	o.vehicles = {IDs = data.vehicleIDs or {}, objects = data.vehicleObjects or {}}
 
 	local mt =
 	{
@@ -970,6 +982,9 @@ end
 function Player:addVehicle(v)
 	local id = type(v) == 'table' and v.serverVehicleString or v
 	self.vehicles.IDs[id] = id
+	if getGameVehicleID(id) then
+		self.vehicles.objects[id] = getObjectByID(getGameVehicleID(id)) or nil
+	end
 	log('W', 'Player:addVehicle', 'Assigned vehicle ID '..tostring(id)..' to player '..self.name)
 end
 function Player:setNickPrefix(tagSource, text)
@@ -1072,7 +1087,7 @@ function Vehicle:delete()
 	for playerID, v in pairs(self.spectators) do
 		if players[playerID] then players[playerID].activeVehicleID = nil end
 	end
-	if players[self.ownerID] and self.serverVehicleString then players[self.ownerID].vehicles.IDs[self.serverVehicleString] = nil end
+	if players[self.ownerID] and self.serverVehicleString then players[self.ownerID].vehicles.IDs[self.serverVehicleString] = nil players[self.ownerID].vehicles.objects[self.serverVehicleString] = nil end
 	if self.serverVehicleString then vehicles[self.serverVehicleString] = nil end
 
 	players_vehicle_configs[self.serverVehicleString] = nil
@@ -2698,6 +2713,9 @@ M.onUIInitialised          = onUIInitialised
 -- FUNCTIONS
 M.restorePlayerVehicle     = restorePlayerVehicle         -- takes: playerID eg 1 2 3 4
 M.getPlayers               = getPlayers               -- takes: -
+M.getPlayerVehicles        = getPlayerVehicles
+M.getPlayerVehicleIDs      = getPlayerVehicleIDs
+M.getPlayerVehicleObjects  = getPlayerVehicleObjects
 M.getVehicles              = getVehicles              -- takes: -
 M.getVehicleByGameID       = getVehicleByGameID       -- takes: number gameID, returns Vehicle
 M.getVehicleByServerID     = getVehicleByServerID     -- takes: string serverVehicleID, returns Vehicle

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -2189,15 +2189,35 @@ end
 local lastGmQuery = -1 --get player pos on first run
 local groundmarkerRoads = {}
 local gmTargetPlayer = nil
-local lastGmFocus = nil
+
+local function updateGroundMarkers()
+	local playerRoadData = groundmarkerRoads['player']
+	if playerRoadData and playerRoadData.first and playerRoadData.first ~= 'nil' then
+		for target, data in pairs(groundmarkerRoads) do
+			if target ~= 'player' then
+				if data.best and data.best ~= core_groundMarkers.getTargetPos() then
+					if activeVehPos:squaredDistance(data.position) > 200 then
+						core_groundMarkers.setFocus(data.best)
+						log('M', 'onPreRender', 'setting focus to '..data.best)
+					else
+						core_groundMarkers.setFocus(nil)
+						groundmarkerRoads[target] = nil
+					end
+				end
+			end
+		end
+	end
+end
 
 local function queryRoadNodeToPosition(targetPosition, owner)
 	if not owner then owner = "target" end
-	targetPosition = vec3(targetPosition)
 	local first, second, distance = map.findClosestRoad(targetPosition)
 	if not first and not second then return false end
-
-	groundmarkerRoads[owner] = {position=targetPosition}
+	if not groundmarkerRoads[owner] then
+		groundmarkerRoads[owner] = {position=targetPosition}
+	else
+		groundmarkerRoads[owner].position:set(targetPosition)
+	end
 	if first ~= 'nil' and second ~= 'nil' then
 		groundmarkerRoads[owner].first = first
 		groundmarkerRoads[owner].next = second
@@ -2207,8 +2227,8 @@ local function queryRoadNodeToPosition(targetPosition, owner)
 		local node2 = mapData.nodes[second]
 		if node1 and node2 then
 			-- find which node is closest to the owner
-			local sqrDist1 = (targetPosition - node1.pos):squaredLength()
-			local sqrDist2 = (targetPosition - node2.pos):squaredLength()
+			local sqrDist1 = targetPosition:squaredDistance(node1.pos)
+			local sqrDist2 = targetPosition:squaredDistance(node2.pos)
 
 			if sqrDist1 < sqrDist2 then groundmarkerRoads[owner].best = first
 			else groundmarkerRoads[owner].best = second end
@@ -2219,19 +2239,22 @@ local function queryRoadNodeToPosition(targetPosition, owner)
 	return false, nil
 end
 
-local function groundmarkerToPlayer(targetName)
+local function groundmarkerToPlayer(targetName, update)
+	if not update then
+		gmTargetPlayer = nil
+		queryRoadNodeToPosition(activeVehPos, 'player')
+		updateGroundMarkers()
+	end
 	if not targetName then
 		groundmarkerRoads["targetVeh"] = nil
-		lastGmFocus = nil
 		core_groundMarkers.setFocus(nil)
 	end
 	for serverVehicleID, vehicle in pairs(vehicles) do
 		if vehicle.ownerName == targetName then
-			local targetVeh = be:getObjectByID(vehicle.gameVehicleID)
-			local targetVehPos = targetVeh:getPosition()
-			local vec3Pos = vec3(targetVehPos.x, targetVehPos.y, targetVehPos.z)
-
-			queryRoadNodeToPosition(vec3Pos, "targetVeh")
+			queryRoadNodeToPosition(vehicle.position, "targetVeh")
+			if not update then
+				updateGroundMarkers()
+			end
 			return
 		end
 	end
@@ -2245,7 +2268,6 @@ local function groundmarkerFollowPlayer(targetName, dontfollow)
 		else
 			gmTargetPlayer = nil
 			groundmarkerRoads["targetVeh"] = nil
-			lastGmFocus = nil
 			core_groundMarkers.setFocus(nil)
 		end
 	end
@@ -2290,6 +2312,19 @@ local function focusCameraOnPlayer(targetName)
 				return
 			end
 		end
+	end
+end
+
+local function groundMarkers(dt)
+	lastGmQuery = lastGmQuery - dt
+	if lastGmQuery <= 0 then
+		lastGmQuery = 0.2
+		queryRoadNodeToPosition(activeVehPos, 'player')
+		if gmTargetPlayer then
+			groundmarkerToPlayer(gmTargetPlayer, true)
+		end
+
+		updateGroundMarkers()
 	end
 end
 
@@ -2357,38 +2392,7 @@ local function onPreRender(dt)
 		local blobColorIllegal = MPHelpers.hex2rgb(settings.getValue("blobColorIllegal"))
 		local blobColorDeleted = MPHelpers.hex2rgb(settings.getValue("blobColorDeleted"))
 
-		-- get current vehicle ID and position
-		local activeVeh = be:getPlayerVehicle(0)
-		local activeVehPos = activeVeh and vec3(activeVeh:getPosition()) or nil
-		local activeVehID = activeVeh and activeVeh:getID() or nil
 
-		-- Groundmarkers
-		if activeVehPos then
-			lastGmQuery = lastGmQuery - dt
-			if lastGmQuery <= 0 then
-				lastGmQuery = 0.2
-				queryRoadNodeToPosition(activeVehPos, 'player')
-				if gmTargetPlayer then groundmarkerToPlayer(gmTargetPlayer) end
-			end
-
-			local playerRoadData = groundmarkerRoads['player']
-			if playerRoadData and playerRoadData.first and playerRoadData.first ~= 'nil' then
-				for target, data in pairs(groundmarkerRoads) do
-					if target ~= 'player' then
-						if data.best and data.best ~= lastGmFocus then
-							if (activeVehPos - data.position):squaredLength() > 200 then
-								core_groundMarkers.setFocus(data.best)
-								log('M', 'onPreRender', 'setting focus to '..data.best)
-								lastGmFocus = data.best
-							else
-								core_groundMarkers.setFocus(nil)
-								groundmarkerRoads[target] = nil
-							end
-						end
-					end
-				end
-			end
-		end
 
 		-- get camera position
 		cameraPos:set(core_camera.getPositionXYZ())
@@ -2400,6 +2404,10 @@ local function onPreRender(dt)
 			if not commands.isFreeCamera() then cameraPos:set(activeVehPos) end
 		end
 
+		local activeVehID = activeVeh and activeVeh:getID() or nil
+		if activeVehID and gmTargetPlayer then
+			groundMarkers(dt)
+		end
 
 		-- apply queue
 		if queueWaiting then

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -2479,7 +2479,7 @@ local function onPreRender(dt)
 			local veh = getObjectByID(gameVehicleID)
 			local heightOffset = 0
 
-			if v.isSpawned and veh then -- update position if available
+			if v.isSpawned and veh and veh:getActive() then -- update position if available
 				if not v.vehicleHeight or v.vehicleHeight == 0 then
 					v.vehicleHeight = veh:getInitialHeight()
 				end

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -43,6 +43,7 @@ local localCounter = 0
 local vehiclesToSync = {}
 local sentPastVehiclesYet = true
 local queueApplyTimer = 0
+local queueWaiting = false
 local isAtSyncSpeed = true
 local hideNicknamesToggle = false
 
@@ -1557,6 +1558,7 @@ local function spawnDestroyedVehicles(serverVehID)
 	if settings.getValue("enableSpawnQueue") then
 		vehicles[serverVehID].spawnQueue = eventdata
 		UI.updateQueue(getQueueCounts())
+		queueWaiting = true
 	else
 		log("D", "restorePlayerVehicle", "Queue disabled, spawning vehicle now")
 		applyVehSpawn(eventdata)
@@ -1847,6 +1849,7 @@ local function onServerVehicleSpawned(playerRole, playerNickname, serverVehicleI
 			log("I", "onServerVehicleSpawned", "Adding spawn for " .. playerNickname .. " to queue")
 
 			vehicles[serverVehicleID].spawnQueue = eventdata
+			queueWaiting = true
 
 			local icon = 'directions_car'
 			if decodedData.jbm == "unicycle" then
@@ -1885,7 +1888,7 @@ local function onServerVehicleEdited(serverID, data)
 
 	if settings.getValue("enableSpawnQueue") and not (settings.getValue("queueSkipUnicycle") and decodedData.jbm == "unicycle") then
 		vehicles[serverID].editQueue = data
-
+		queueWaiting = true
 		log('I', 'onServerVehicleEdited', "edit "..serverID.." queued")
 		local playerNickname = owner and owner.name or "unknown"
 		UI.updateQueue(getQueueCounts())
@@ -2007,10 +2010,12 @@ local function onServerVehicleColorChanged(serverVehicleID, data)
             local decodedData = jsonDecode(vehicle.spawnQueue.data)
             decodedData.vcf.paints = jsonDecode(data)
             vehicle.spawnQueue.data = jsonEncode(decodedData)
+			queueWaiting = true
         elseif vehicle.editQueue then
             local decodedData = jsonDecode(vehicle.editQueue)
             decodedData.vcf.paints = jsonDecode(data)
             vehicle.editQueue = jsonEncode(decodedData)
+			queueWaiting = true
         end
 
         local deletedVehicleData = players_vehicle_configs[serverVehicleID]
@@ -2168,13 +2173,14 @@ end
 
 local function sendPendingVehicleEdits()
 	for gameVehicleID,_ in pairs(vehiclesToSync) do
-		local veh = be:getObjectByID(gameVehicleID)
+		local veh = getObjectByID(gameVehicleID)
 		if veh and isOwn(veh:getID()) then
 			log('I', "syncVehicles", "Autosyncing vehicle "..gameVehicleID)
 			sendVehicleEdit(gameVehicleID)
 		end
+		vehiclesToSync[gameVehicleID] = nil
 	end
-	vehiclesToSync = {}
+	--vehiclesToSync = {}
 end
 
 
@@ -2301,22 +2307,39 @@ local function applyVehicleQueues(serverVehicleID, vehicle)
 end
 
 local function applyQueuedEvents()
+	local queueChanged = false
 	for serverVehicleID, vehicle in pairs(vehicles) do
-		applyVehicleQueues(serverVehicleID, vehicle)
+		if vehicle.spawnQueue or vehicle.editQueue then
+			applyVehicleQueues(serverVehicleID, vehicle)
+			queueChanged = true
+		end
 	end
-
-	UI.updateQueue(getQueueCounts())
+	if queueChanged then
+		UI.updateQueue(getQueueCounts())
+	end
+	queueWaiting = false
 	--if currentVeh then be:enterVehicle(0, currentVeh) print("entered "..currentVeh:getJBeamFilename()) end -- Camera fix
 end
 
 local function applyPlayerQueues(playerID)
+	local queueEmpty = true
+	local queueChanged = false
 	for serverVehicleID, vehicle in pairs(vehicles) do
-		if vehicle.ownerID == playerID then
-			applyVehicleQueues(serverVehicleID, vehicle)
+		if vehicle.spawnQueue or vehicle.editQueue then
+			if vehicle.ownerID == playerID then
+				applyVehicleQueues(serverVehicleID, vehicle)
+				queueChanged = true
+			else
+				queueEmpty = false
+			end
 		end
 	end
-
-	UI.updateQueue(getQueueCounts())
+	if queueChanged then
+		UI.updateQueue(getQueueCounts())
+	end
+	if queueEmpty then
+		queueWaiting = false
+	end
 end
 
 local function onUpdate(dt)
@@ -2367,42 +2390,52 @@ local function onPreRender(dt)
 			end
 		end
 
+		-- get camera position
+		cameraPos:set(core_camera.getPositionXYZ())
 
-		-- get camera position, apply queue
-		local cameraPos = vec3(core_camera.getPosition())
+		-- get current vehicle ID and position
+		local activeVeh = getPlayerVehicle(0)
 		if activeVeh then
-			if not commands.isFreeCamera() then cameraPos = activeVehPos end
-
-			if settings.getValue("queueAutoSkipRemote") and not isOwn(activeVehID) then applyQueuedEvents() end
-
-			if settings.getValue("enableQueueAuto") then
-				local vehicleSpd = math.abs(activeVeh:getVelocity():length() or 0)
-
-				local maxSyncSpd = settings.getValue("queueApplySpeed")
-				local maxTime = settings.getValue("queueApplyTimeout")
+			activeVehPos:set(activeVeh:getPositionXYZ())
+			if not commands.isFreeCamera() then cameraPos:set(activeVehPos) end
+		end
 
 
-				-- If below set speed
-				if (vehicleSpd <= maxSyncSpd) then
-					queueApplyTimer = queueApplyTimer + dt
-					guihooks.trigger("onBeamMPSetAutoQueueProgress", tostring((queueApplyTimer / maxTime)*100))
-					-- if time under speed more than or equal to max
-					if (queueApplyTimer >= maxTime) then
-						applyQueuedEvents()
+		-- apply queue
+		if queueWaiting then
+			if activeVeh then
+				if settings.getValue("queueAutoSkipRemote") and not isOwn(activeVehID) then applyQueuedEvents() end
+
+				if settings.getValue("enableQueueAuto") then
+					vehVel:set(activeVeh:getVelocityXYZ())
+					local vehicleSpd = math.abs(vehVel:squaredLength() or 0)
+
+					local maxSyncSpd = settings.getValue("queueApplySpeed")
+					local maxTime = settings.getValue("queueApplyTimeout")
+
+
+					-- If below set speed
+					if (vehicleSpd <= maxSyncSpd^2) then
+						queueApplyTimer = queueApplyTimer + dt
+						guihooks.trigger("onBeamMPSetAutoQueueProgress", tostring((queueApplyTimer / maxTime)*100))
+						-- if time under speed more than or equal to max
+						if (queueApplyTimer >= maxTime) then
+							applyQueuedEvents()
+							queueApplyTimer = 0
+						end
+					else -- Reset timer and UI
+						if queueApplyTimer > 0 then
+							guihooks.trigger("onBeamMPSetAutoQueueProgress", "0")
+						end
 						queueApplyTimer = 0
 					end
-				else -- Reset timer and UI
-					if queueApplyTimer > 0 then
-						guihooks.trigger("onBeamMPSetAutoQueueProgress", "0")
-					end
-					queueApplyTimer = 0
 				end
-			end
-		else
-			queueApplyTimer = 0
-			applyQueuedEvents()
-			if not commands.isFreeCamera() then
-				commands.setFreeCamera()		-- Fix camera
+			else
+				queueApplyTimer = 0
+				applyQueuedEvents()
+				if not commands.isFreeCamera() then
+					commands.setFreeCamera()		-- Fix camera
+				end
 			end
 		end
 

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -67,6 +67,7 @@ end
 
 -- debug drawers, using the FFI functions for debugDraw is a lot faster and produces no garbage
 local drawTextAdvanced = ffiFound and ffi.C.BNG_DBG_DRAW_TextAdvanced or nop
+local drawSphere = ffiFound and ffi.C.BNG_DBG_DRAW_Sphere or nop
 
 --- Contains Information about Backend authorized Roles
 -- @table roleToInfo
@@ -2386,13 +2387,33 @@ local function onUpdate(dt)
   --playerTags.updatePositions()
 end
 
+local hasInitColors = false
+
+local blobColorQueued =  color(0,0,0,127)
+local blobColorIllegal = color(0,0,0,127)
+local blobColorDeleted = color(0,0,0,127)
+
+local blobColorFallBack = color(255, 0, 255, 127)
+
+local function initColors()
+	if MPHelpers then
+		local rgbaBlobColorQueued = MPHelpers.hex2rgb(settings.getValue("blobColorQueued"))
+		local rgbaBlobColorIllegal = MPHelpers.hex2rgb(settings.getValue("blobColorIllegal"))
+		local rgbaBlobColorDeleted = MPHelpers.hex2rgb(settings.getValue("blobColorDeleted"))
+
+		blobColorQueued =  color(rgbaBlobColorQueued[1]*255,rgbaBlobColorQueued[2]*255,rgbaBlobColorQueued[3]*255,127)
+		blobColorIllegal = color(rgbaBlobColorIllegal[1]*255,rgbaBlobColorIllegal[2]*255,rgbaBlobColorIllegal[3]*255,127)
+		blobColorDeleted = color(rgbaBlobColorDeleted[1]*255,rgbaBlobColorDeleted[2]*255,rgbaBlobColorDeleted[3]*255,127)
+		hasInitColors = true
+	end
+end
+
+
 local function onPreRender(dt)
 	if MPGameNetwork and MPGameNetwork.launcherConnected() then
-		local blobColorQueued = MPHelpers.hex2rgb(settings.getValue("blobColorQueued"))
-		local blobColorIllegal = MPHelpers.hex2rgb(settings.getValue("blobColorIllegal"))
-		local blobColorDeleted = MPHelpers.hex2rgb(settings.getValue("blobColorDeleted"))
-
-
+		if not hasInitColors then
+			initColors()
+		end
 
 		-- get camera position
 		cameraPos:set(core_camera.getPositionXYZ())
@@ -2500,11 +2521,11 @@ local function onPreRender(dt)
 						colors = blobColorDeleted
 					end
 				else
-					colors = { 1, 0, 1 }
+					colors = blobColorFallBack
 				end
 
 				if colors then
-					debugDrawer:drawSphere(pos, 1, ColorF(colors[1], colors[2], colors[3], 0.5))
+					drawSphere(pos.x, pos.y, pos.z, 1, colors, true)
 					pos.z = pos.z + 1
 				end
 			end
@@ -2742,6 +2763,7 @@ local function onSettingsChanged()
 	--
 	--	settingsCache[k]  = ColorF(table.unpack(p))
 	--end
+	initColors()
 end
 
 detectGlobalWrites() -- reenable global write notifications

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -2275,19 +2275,12 @@ local function groundmarkerFollowPlayer(targetName, dontfollow)
 end
 
 local function teleportVehToPlayer(targetName)
-	local activeVehicle = be:getPlayerVehicle(0)
+	local activeVehicle = getPlayerVehicle(0)
 
 	if activeVehicle then
 		for serverVehicleID, vehicle in pairs(vehicles) do
 			if vehicle.ownerName == targetName then
-				--print("teleporting to "..tostring(i))
-				local targetVeh = be:getObjectByID(vehicle.gameVehicleID)
-				local targetVehPos = targetVeh:getPosition()
-				local targetVehRot = quatFromDir(vec3(targetVeh:getDirectionVector()), vec3(targetVeh:getDirectionVectorUp()))
-
-				local vec3Pos = vec3(targetVehPos.x, targetVehPos.y, targetVehPos.z)
-
-				spawn.safeTeleport(activeVehicle, vec3Pos, targetVehRot, false)
+				spawn.safeTeleport(activeVehicle, vehicle.position, vehicle.rotation, false)
 				return
 			end
 		end
@@ -2298,14 +2291,14 @@ local function teleportVehToPlayer(targetName)
 end
 
 local function focusCameraOnPlayer(targetName)
-	local activeVehicle = be:getPlayerVehicle(0)
+	local activeVehicle = getPlayerVehicle(0)
 	local activeVehicleID = activeVehicle and activeVehicle:getID() or nil
 	log('I', "focusCameraOnPlayer", "Teleporting camera to: "..targetName)
 
 	for serverVehicleID, vehicle in pairs(vehicles) do
 		if vehicle.ownerName == targetName and vehicle.jbeam ~= "unicycle" then
 			log('I', "focusCameraOnPlayer", "Found vehicle: "..vehicle.gameVehicleID)
-			local targetVeh = be:getObjectByID(vehicle.gameVehicleID)
+			local targetVeh = getObjectByID(vehicle.gameVehicleID)
 
 			if vehicle.gameVehicleID ~= activeVehicleID and targetVeh then
 				log('I', "focusCameraOnPlayer", "Entering vehicle "..vehicle.gameVehicleID)
@@ -2483,7 +2476,7 @@ local function onPreRender(dt)
 			local owner = v:getOwner()
 			if v.isLocal or not owner then goto skip_vehicle end
 			local gameVehicleID = v.gameVehicleID
-			local veh = be:getObjectByID(gameVehicleID)
+			local veh = getObjectByID(gameVehicleID)
 			local heightOffset = 0
 
 			if v.isSpawned and veh then -- update position if available
@@ -2533,7 +2526,7 @@ local function onPreRender(dt)
 			local nametagAlpha = 1
 			local nametagFadeoutDistance = settings.getValue("nameTagFadeDistance", 40)
 
-			local distfloat = (cameraPos or vec3()):distance(pos)
+			local distfloat = cameraPos:distance(pos)
 			distanceMap[gameVehicleID] = distfloat
 			nametagAlpha = clamp(linearScale(distfloat, nametagFadeoutDistance, 0, 0, 1), 0, 1)
 

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1278,7 +1278,7 @@ local function sendVehicleSpawn(gameVehicleID)
 		vehicleTable.vcf.licenseName = veh:getDynDataFieldbyName("licenseText", 0)
 
 		local stringToSend = jsonEncode(vehicleTable) -- Encode table to send it as json string
-		MPGameNetwork.send('Os:0:'..stringToSend) -- Send table that contain all vehicle informations for each vehicle
+		MPGameNetwork.send(MPHelpers.generatePacketBuffer('Os',0,stringToSend)) -- Send table that contain all vehicle informations for each vehicle
 		log('I', "sendVehicle", "Vehicle "..gameVehicleID.." was sent")
 
 		--local vehObj = Vehicle:new({ isLocal=true, ownerName=MPConfig.getNickname(), gameVehicleID=gameVehicleID, jbeam=vehicleTable.jbm, ownerID=vehicleTable.pid })
@@ -1323,13 +1323,13 @@ local function sendVehicleEdit(gameVehicleID)
 	vehicleTable.vcf.licenseName = veh:getDynDataFieldbyName("licenseText", 0)
 
 	local stringToSend = jsonEncode(vehicleTable) -- Encode table to send it as json string
-	MPGameNetwork.send('Oc:'..getServerVehicleID(gameVehicleID)..':'..stringToSend) -- Send table that contain all vehicle informations for each vehicle
+	MPGameNetwork.send(MPHelpers.generatePacketBuffer('Oc',getServerVehicleID(gameVehicleID),stringToSend)) -- Send table that contain all vehicle informations for each vehicle
 	log('I', "sendVehicleEdit", "Vehicle custom data "..gameVehicleID.." was sent")
 	vehiclesToSync[gameVehicleID] = nil
 end
 
 local function sendBeamstate(data, gameVehicleID)
-	MPGameNetwork.send('Ot:'..getServerVehicleID(gameVehicleID)..':'..data)
+	MPGameNetwork.send(MPHelpers.generatePacketBuffer('Ot',getServerVehicleID(gameVehicleID),data))
 end
 
 
@@ -1707,7 +1707,7 @@ local function onVehicleDestroyed(gameVehicleID)
 							handle:close()
 						end
 					end
-					MPGameNetwork.send('Od:'..serverVehicleID)
+					MPGameNetwork.send(MPHelpers.generatePacketBuffer('Od',serverVehicleID))
 					vehicles[serverVehicleID]:delete()
 				end
 			end
@@ -1727,9 +1727,7 @@ local function sendActiveVehicleID(newVehObj)
 	end
 	if newServerVehicleID then
 		local playerID = MPConfig.getPlayerServerID()
-		local s = tostring(playerID) .. ':' .. newServerVehicleID
-
-		MPGameNetwork.send('Om:'.. s)
+		MPGameNetwork.send(MPHelpers.generatePacketBuffer('Om',tostring(playerID),newServerVehicleID))
 	end
 end
 
@@ -1825,7 +1823,7 @@ local function onVehicleResetted(gameVehicleID)
 					w = rot.w
 				}
 			}
-			MPGameNetwork.send('Or:'..vehicle.serverVehicleString..":"..jsonEncode(tempTable).."")
+			MPGameNetwork.send(MPHelpers.generatePacketBuffer('Or',vehicle.serverVehicleString,jsonEncode(tempTable)))
 		elseif vehicle then -- apply ABS behavior on nonlocal vehicles
 			local veh = be:getObjectByID(gameVehicleID)
 			local absMode = veh:getField("absMode", 0)
@@ -1846,8 +1844,7 @@ local function onVehicleColorChanged(gameVehicleID, index, paint)
         local veh = getObjectByID(gameVehicleID) -- get vehicle as object
 		local paintData =  MPHelpers.getColorsFromVehObj(veh)
         paintData[index] = paint --insert new paint at index as chosen from color picker
-
-		MPGameNetwork.send('Op:'..vehicle.serverVehicleString..":"..jsonEncode(paintData).."")
+		MPGameNetwork.send(MPHelpers.generatePacketBuffer('Op',vehicle.serverVehicleString,jsonEncode(paintData)))
     end
 end
 

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1991,6 +1991,7 @@ local function onServerVehicleRemoved(serverVehicleID)
 		UI.updateQueue(getQueueCounts())
 		return
 	end
+	local updateQueueUi = vehicle.editQueue and true or false
 
 	local gameVehicleID = vehicle.gameVehicleID
 	if gameVehicleID > 0 then
@@ -2010,6 +2011,10 @@ local function onServerVehicleRemoved(serverVehicleID)
 	else
 		log('W', "onServerVehicleRemoved", "Failed removing vehicle "..serverVehicleID..", ID is unknown")
 		vehicle:delete()
+	end
+
+	if updateQueueUi then
+		UI.updateQueue(getQueueCounts())
 	end
 end
 

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -2793,6 +2793,13 @@ local function onExtensionLoaded()
 	onSettingsChanged()
 end
 
+local function refreshNametagCache()
+	for playerID,player in pairs(players) do
+		player:updateNameTagCache()
+		player:updateSpectatorsTagCache()
+	end
+end
+
 local function onSettingsChanged()
 	for playerID,player in pairs(players) do
 		player:onSettingsChanged()
@@ -2859,6 +2866,7 @@ M.setVehicleRole           = setVehicleRole           -- takes: string playerIDv
 M.clearVehicleRole         = clearVehicleRole         -- takes: string playerIDVehicleID
 M.setPlayerRole            = setPlayerRole            -- takes: string playerID, string tag, string shorttag, number red, number green, number blue
 M.clearPlayerRole          = clearPlayerRole          -- takes: string playerID
+M.refreshNametagCache      = refreshNametagCache
 M.getGameVehicleID         = getGameVehicleID         -- takes: -      returns: { 'gamevehid' : 'servervehid', '23456' : '1-2' }
 M.getServerVehicleID       = getServerVehicleID       -- takes: -      returns: { 'servervehid' : 'gamevehid', '1-2' : '23456' }
 M.saveDefaultRequest       = saveDefaultRequest       -- takes: -

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1278,7 +1278,7 @@ local function sendVehicleSpawn(gameVehicleID)
 		vehicleTable.vcf.licenseName = veh:getDynDataFieldbyName("licenseText", 0)
 
 		local stringToSend = jsonEncode(vehicleTable) -- Encode table to send it as json string
-		MPGameNetwork.send(MPHelpers.generatePacketBuffer('Os',0,stringToSend)) -- Send table that contain all vehicle informations for each vehicle
+		MPGameNetwork.send(MPNetworkHelpers.generatePacketBuffer('Os',0,stringToSend)) -- Send table that contain all vehicle informations for each vehicle
 		log('I', "sendVehicle", "Vehicle "..gameVehicleID.." was sent")
 
 		--local vehObj = Vehicle:new({ isLocal=true, ownerName=MPConfig.getNickname(), gameVehicleID=gameVehicleID, jbeam=vehicleTable.jbm, ownerID=vehicleTable.pid })
@@ -1323,13 +1323,13 @@ local function sendVehicleEdit(gameVehicleID)
 	vehicleTable.vcf.licenseName = veh:getDynDataFieldbyName("licenseText", 0)
 
 	local stringToSend = jsonEncode(vehicleTable) -- Encode table to send it as json string
-	MPGameNetwork.send(MPHelpers.generatePacketBuffer('Oc',getServerVehicleID(gameVehicleID),stringToSend)) -- Send table that contain all vehicle informations for each vehicle
+	MPGameNetwork.send(MPNetworkHelpers.generatePacketBuffer('Oc',getServerVehicleID(gameVehicleID),stringToSend)) -- Send table that contain all vehicle informations for each vehicle
 	log('I', "sendVehicleEdit", "Vehicle custom data "..gameVehicleID.." was sent")
 	vehiclesToSync[gameVehicleID] = nil
 end
 
 local function sendBeamstate(data, gameVehicleID)
-	MPGameNetwork.send(MPHelpers.generatePacketBuffer('Ot',getServerVehicleID(gameVehicleID),data))
+	MPGameNetwork.send(MPNetworkHelpers.generatePacketBuffer('Ot',getServerVehicleID(gameVehicleID),data))
 end
 
 
@@ -1707,7 +1707,7 @@ local function onVehicleDestroyed(gameVehicleID)
 							handle:close()
 						end
 					end
-					MPGameNetwork.send(MPHelpers.generatePacketBuffer('Od',serverVehicleID))
+					MPGameNetwork.send(MPNetworkHelpers.generatePacketBuffer('Od',serverVehicleID))
 					vehicles[serverVehicleID]:delete()
 				end
 			end
@@ -1727,7 +1727,7 @@ local function sendActiveVehicleID(newVehObj)
 	end
 	if newServerVehicleID then
 		local playerID = MPConfig.getPlayerServerID()
-		MPGameNetwork.send(MPHelpers.generatePacketBuffer('Om',tostring(playerID),newServerVehicleID))
+		MPGameNetwork.send(MPNetworkHelpers.generatePacketBuffer('Om',tostring(playerID),newServerVehicleID))
 	end
 end
 
@@ -1823,7 +1823,7 @@ local function onVehicleResetted(gameVehicleID)
 					w = rot.w
 				}
 			}
-			MPGameNetwork.send(MPHelpers.generatePacketBuffer('Or',vehicle.serverVehicleString,jsonEncode(tempTable)))
+			MPGameNetwork.send(MPNetworkHelpers.generatePacketBuffer('Or',vehicle.serverVehicleString,jsonEncode(tempTable)))
 		elseif vehicle then -- apply ABS behavior on nonlocal vehicles
 			local veh = be:getObjectByID(gameVehicleID)
 			local absMode = veh:getField("absMode", 0)
@@ -1844,7 +1844,7 @@ local function onVehicleColorChanged(gameVehicleID, index, paint)
         local veh = getObjectByID(gameVehicleID) -- get vehicle as object
 		local paintData =  MPHelpers.getColorsFromVehObj(veh)
         paintData[index] = paint --insert new paint at index as chosen from color picker
-		MPGameNetwork.send(MPHelpers.generatePacketBuffer('Op',vehicle.serverVehicleString,jsonEncode(paintData)))
+		MPGameNetwork.send(MPNetworkHelpers.generatePacketBuffer('Op',vehicle.serverVehicleString,jsonEncode(paintData)))
     end
 end
 

--- a/lua/ge/extensions/UI.lua
+++ b/lua/ge/extensions/UI.lua
@@ -52,11 +52,6 @@ M.uiIcons = {
     user = 0,
 }
 
-local ImVec2_uv0 = imgui.ImVec2(0,0)
-local ImVec2_uv1 = imgui.ImVec2(1,1)
-local ImVec4_bg_col = imgui.ImVec4(0,0,0,0)
-local ImVec4_tint_col = imgui.ImVec4(1,1,1,1)
-
 local windowOpacity = 0.9
 
 M.windowOpen = imgui.BoolPtr(true)

--- a/lua/ge/extensions/UI.lua
+++ b/lua/ge/extensions/UI.lua
@@ -22,6 +22,25 @@ local imu = require('ui/imguiUtils')
 local utils = require("beammp.ui.utils")
 local configLoaded = false
 
+-- a temp vector only works once in the same function call
+-- if more vectors are needed, for example like im.function(pos1, pos2), then a tempVec2/4 would need to be created for each field
+
+local tempVec2 = imgui.ImVec2(0,0)
+local function useTempVec2(x,y)
+  tempVec2.x = x
+  tempVec2.y = y
+  return tempVec2
+end
+
+local tempVec4 = imgui.ImVec4(0,0,0,0)
+local function useTempVec4(x,y,z,w)
+  tempVec4.x = x
+  tempVec4.y = y
+  tempVec4.z = z
+  tempVec4.w = w
+  return tempVec4
+end
+
 M.uiIcons = {
     settings = 0,
     send = 0,
@@ -32,6 +51,11 @@ M.uiIcons = {
     back = 0,
     user = 0,
 }
+
+local ImVec2_uv0 = imgui.ImVec2(0,0)
+local ImVec2_uv1 = imgui.ImVec2(1,1)
+local ImVec4_bg_col = imgui.ImVec4(0,0,0,0)
+local ImVec4_tint_col = imgui.ImVec4(1,1,1,1)
 
 local windowOpacity = 0.9
 
@@ -243,43 +267,45 @@ end
 -- -------------------------------------------------------------
 
 --- Render the IMGUI chat window and playerlist windows + the settings for them.
-local function renderWindow()
+local function renderWindow(dtRaw)
     if not configLoaded then return end
 
-    imgui.PushStyleVar2(imgui.StyleVar_WindowMinSize, (collapsed and imgui.ImVec2(lastSize.x, 20)) or M.windowMinSize)
+    imgui.PushStyleVar2(imgui.StyleVar_WindowMinSize, (collapsed and useTempVec2(lastSize.x, 20)) or M.windowMinSize)
 
     imgui.PushStyleVar2(imgui.StyleVar_WindowPadding, M.windowPadding)
     imgui.PushStyleVar1(imgui.StyleVar_WindowBorderSize, 0)
 
-    imgui.PushStyleColor2(imgui.Col_WindowBg, imgui.ImVec4(M.settings.colors.windowBackground.x, M.settings.colors.windowBackground.y, M.settings.colors.windowBackground.z, windowOpacity))
-    imgui.PushStyleColor2(imgui.Col_CheckMark, imgui.ImVec4(M.settings.colors.buttonActive.x, M.settings.colors.buttonActive.y, M.settings.colors.buttonActive.z, windowOpacity))
+    imgui.PushStyleColor2(imgui.Col_WindowBg, useTempVec4(M.settings.colors.windowBackground.x, M.settings.colors.windowBackground.y, M.settings.colors.windowBackground.z, windowOpacity))
+    imgui.PushStyleColor2(imgui.Col_CheckMark, useTempVec4(M.settings.colors.buttonActive.x, M.settings.colors.buttonActive.y, M.settings.colors.buttonActive.z, windowOpacity))
 
-    imgui.PushStyleColor2(imgui.Col_Button, imgui.ImVec4(M.settings.colors.buttonBackground.x, M.settings.colors.buttonBackground.y, M.settings.colors.buttonBackground.z, windowOpacity))
-    imgui.PushStyleColor2(imgui.Col_ButtonHovered, imgui.ImVec4(M.settings.colors.buttonHovered.x, M.settings.colors.buttonHovered.y, M.settings.colors.buttonHovered.z, windowOpacity))
-    imgui.PushStyleColor2(imgui.Col_ButtonActive, imgui.ImVec4(M.settings.colors.buttonActive.x, M.settings.colors.buttonActive.y, M.settings.colors.buttonActive.z, windowOpacity))
+    imgui.PushStyleColor2(imgui.Col_Button, useTempVec4(M.settings.colors.buttonBackground.x, M.settings.colors.buttonBackground.y, M.settings.colors.buttonBackground.z, windowOpacity))
+    imgui.PushStyleColor2(imgui.Col_ButtonHovered, useTempVec4(M.settings.colors.buttonHovered.x, M.settings.colors.buttonHovered.y, M.settings.colors.buttonHovered.z, windowOpacity))
+    imgui.PushStyleColor2(imgui.Col_ButtonActive, useTempVec4(M.settings.colors.buttonActive.x, M.settings.colors.buttonActive.y, M.settings.colors.buttonActive.z, windowOpacity))
 
-    imgui.PushStyleColor2(imgui.Col_Text, imgui.ImVec4(M.settings.colors.textColor.x, M.settings.colors.textColor.y, M.settings.colors.textColor.z, windowOpacity))
+    imgui.PushStyleColor2(imgui.Col_Text, useTempVec4(M.settings.colors.textColor.x, M.settings.colors.textColor.y, M.settings.colors.textColor.z, windowOpacity))
 
-    imgui.PushStyleColor2(imgui.Col_ResizeGrip, imgui.ImVec4(M.settings.colors.primaryColor.x, M.settings.colors.primaryColor.y, M.settings.colors.primaryColor.z, windowOpacity))
-    imgui.PushStyleColor2(imgui.Col_ResizeGripHovered, imgui.ImVec4(M.settings.colors.secondaryColor.x, M.settings.colors.secondaryColor.y, M.settings.colors.secondaryColor.z, windowOpacity))
-    imgui.PushStyleColor2(imgui.Col_ResizeGripActive, imgui.ImVec4(M.settings.colors.secondaryColor.x, M.settings.colors.secondaryColor.y, M.settings.colors.secondaryColor.z, windowOpacity))
+    imgui.PushStyleColor2(imgui.Col_ResizeGrip, useTempVec4(M.settings.colors.primaryColor.x, M.settings.colors.primaryColor.y, M.settings.colors.primaryColor.z, windowOpacity))
+    imgui.PushStyleColor2(imgui.Col_ResizeGripHovered, useTempVec4(M.settings.colors.secondaryColor.x, M.settings.colors.secondaryColor.y, M.settings.colors.secondaryColor.z, windowOpacity))
+    imgui.PushStyleColor2(imgui.Col_ResizeGripActive, useTempVec4(M.settings.colors.secondaryColor.x, M.settings.colors.secondaryColor.y, M.settings.colors.secondaryColor.z, windowOpacity))
 
-    imgui.PushStyleColor2(imgui.Col_Separator, imgui.ImVec4(M.settings.colors.secondaryColor.x, M.settings.colors.secondaryColor.y, M.settings.colors.secondaryColor.z, windowOpacity))
-    imgui.PushStyleColor2(imgui.Col_SeparatorHovered, imgui.ImVec4(M.settings.colors.secondaryColor.x, M.settings.colors.secondaryColor.y, M.settings.colors.secondaryColor.z, windowOpacity))
-    imgui.PushStyleColor2(imgui.Col_SeparatorActive, imgui.ImVec4(M.settings.colors.secondaryColor.x, M.settings.colors.secondaryColor.y, M.settings.colors.secondaryColor.z, windowOpacity))
+    imgui.PushStyleColor2(imgui.Col_Separator, useTempVec4(M.settings.colors.secondaryColor.x, M.settings.colors.secondaryColor.y, M.settings.colors.secondaryColor.z, windowOpacity))
+    imgui.PushStyleColor2(imgui.Col_SeparatorHovered, useTempVec4(M.settings.colors.secondaryColor.x, M.settings.colors.secondaryColor.y, M.settings.colors.secondaryColor.z, windowOpacity))
+    imgui.PushStyleColor2(imgui.Col_SeparatorActive, useTempVec4(M.settings.colors.secondaryColor.x, M.settings.colors.secondaryColor.y, M.settings.colors.secondaryColor.z, windowOpacity))
 
-    imgui.PushStyleColor2(imgui.Col_ScrollbarBg, imgui.ImVec4(M.settings.colors.primaryColor.x, M.settings.colors.primaryColor.y, M.settings.colors.primaryColor.z, windowOpacity))
-    imgui.PushStyleColor2(imgui.Col_ScrollbarGrab, imgui.ImVec4(M.settings.colors.secondaryColor.x, M.settings.colors.secondaryColor.y, M.settings.colors.secondaryColor.z, windowOpacity))
-    imgui.PushStyleColor2(imgui.Col_ScrollbarGrabHovered, imgui.ImVec4(M.settings.colors.secondaryColor.x, M.settings.colors.secondaryColor.y, M.settings.colors.secondaryColor.z, windowOpacity))
-    imgui.PushStyleColor2(imgui.Col_ScrollbarGrabActive, imgui.ImVec4(M.settings.colors.secondaryColor.x, M.settings.colors.secondaryColor.y, M.settings.colors.secondaryColor.z, windowOpacity))
+    imgui.PushStyleColor2(imgui.Col_ScrollbarBg, useTempVec4(M.settings.colors.primaryColor.x, M.settings.colors.primaryColor.y, M.settings.colors.primaryColor.z, windowOpacity))
+    imgui.PushStyleColor2(imgui.Col_ScrollbarGrab, useTempVec4(M.settings.colors.secondaryColor.x, M.settings.colors.secondaryColor.y, M.settings.colors.secondaryColor.z, windowOpacity))
+    imgui.PushStyleColor2(imgui.Col_ScrollbarGrabHovered, useTempVec4(M.settings.colors.secondaryColor.x, M.settings.colors.secondaryColor.y, M.settings.colors.secondaryColor.z, windowOpacity))
+    imgui.PushStyleColor2(imgui.Col_ScrollbarGrabActive, useTempVec4(M.settings.colors.secondaryColor.x, M.settings.colors.secondaryColor.y, M.settings.colors.secondaryColor.z, windowOpacity))
 
     if collapsed then
-        imgui.SetNextWindowSize(imgui.ImVec2(lastSize.x, 30))
+        imgui.SetNextWindowSize(useTempVec2(lastSize.x, 30))
     elseif not firstRender then
-        imgui.SetNextWindowSize(imgui.ImVec2(lastSize.x, lastSize.y))
+        imgui.SetNextWindowSize(useTempVec2(lastSize.x, lastSize.y))
     end
 
+
     if imgui.Begin("BeamMP Chat", M.windowOpen, (collapsed and M.windowCollapsedFlags or M.windowFlags)) then
+
         if not collapsed then
             lastSize = imgui.GetWindowSize()
         end
@@ -292,9 +318,9 @@ local function renderWindow()
                 windowOpacity = 0.9
                 fadeTimer = 0
             else
-                fadeTimer = fadeTimer + imgui.GetIO().DeltaTime
+                fadeTimer = fadeTimer + dtRaw --imgui.GetIO().DeltaTime
                 if fadeTimer > M.settings.window.fadeTime then
-                    windowOpacity = windowOpacity - 0.05
+                    windowOpacity = windowOpacity - (dtRaw*2)
                     if windowOpacity < 0 then
                         windowOpacity = 0
                     end
@@ -313,11 +339,12 @@ local function renderWindow()
                 windowTitle = "BeamMP Chat"
             end
         end
-
         -- Titlebar
         imgui.PushStyleVar1(imgui.StyleVar_Alpha, windowOpacity)
-        if imgui.BeginChild1("ChatTitlebar", imgui.ImVec2(0, 30), false) then
-            imgui.SetCursorPosX(imgui.GetStyle().ItemSpacing.x)
+        if windowOpacity >= 0 and imgui.BeginChild1("ChatTitlebar", useTempVec2(0, 30), false) then
+
+            local ItemSpaceX = imgui.GetStyle().ItemSpacing.x
+            imgui.SetCursorPosX(ItemSpaceX)
             if currentWindow ~= windows.chat then
                 local oldPosY = imgui.GetCursorPosY()
                 imgui.SetCursorPosY(imgui.GetCursorPosY() + 4)
@@ -325,12 +352,11 @@ local function renderWindow()
                     currentWindow = windows.chat
                 end
                 imgui.SameLine()
-                imgui.SetCursorPosX(imgui.GetStyle().ItemSpacing.x + 20)
+                imgui.SetCursorPosX(ItemSpaceX + 20)
                 imgui.SetCursorPosY(oldPosY)
             end
 
             imgui.Text(windowTitle)
-
             -- Collapsed
             imgui.SameLine()
             imgui.SetCursorPosX(imgui.GetWindowWidth() - 60)
@@ -362,7 +388,7 @@ local function renderWindow()
         end
         imgui.EndChild()
 
-        if not collapsed then
+        if not collapsed and windowOpacity >= 0 then
             currentWindow.render()
         end
         imgui.PopStyleVar()
@@ -541,9 +567,9 @@ end
 --- onUpdate is a game eventloop function. It is called each frame by the game engine.
 -- This is the main processing thread of BeamMP in the game
 -- @param dt float
-local function onUpdate(dt)
+local function onUpdate(dtReal,dtSim,dtRaw)
     if worldReadyState ~= 2 or not settings.getValue("enableNewChatMenu") or not initialized or not M.canRender or MPCoreNetwork and not MPCoreNetwork.isMPSession() then return end
-    renderWindow()
+    renderWindow(dtRaw)
 end
 
 local customPlayerlistButtons = {

--- a/lua/ge/extensions/beammp/multiplayer.lua
+++ b/lua/ge/extensions/beammp/multiplayer.lua
@@ -142,7 +142,9 @@ local function onWorldReadyState(state)
 		if MPCoreNetwork and MPCoreNetwork.isMPSession() then
 			log('M', 'onWorldReadyState', 'Setting game state to BeamMP multiplayer.')
 			local spawnDefaultGroups = { "CameraSpawnPoints", "PlayerSpawnPoints", "PlayerDropPoints", "spawnpoints" }
-
+			if not commands.isFreeCamera() then
+				commands.setFreeCamera()
+			end
 			for i, v in pairs(spawnDefaultGroups) do
 				if scenetree.findObject(spawnDefaultGroups[i]) then
 					local spawngroupPoint = scenetree.findObject(spawnDefaultGroups[i]):getRandom()

--- a/lua/ge/extensions/beammp/ui/chat.lua
+++ b/lua/ge/extensions/beammp/ui/chat.lua
@@ -35,6 +35,25 @@ local function colorByRGB(r, g, b, a)
     return imgui.ImVec4(r/255, g/255, b/255, a/255)
 end
 
+-- a temp vector only works once in the same function call
+-- if more vectors are needed, for example like im.function(pos1, pos2), then a tempVec2/4 would need to be created for each field
+
+local tempVec2 = imgui.ImVec2(0,0)
+local function useTempVec2(x,y)
+  tempVec2.x = x
+  tempVec2.y = y
+  return tempVec2
+end
+
+local tempVec4 = imgui.ImVec4(0,0,0,0)
+local function useTempVec4(x,y,z,w)
+  tempVec4.x = x
+  tempVec4.y = y
+  tempVec4.z = z
+  tempVec4.w = w
+  return tempVec4
+end
+
 
 local colorCodes = {
     ['0'] = colorByRGB(000,000,000,255),
@@ -82,7 +101,9 @@ local function textToColorAndText(text, nocolor)
             else
                 table.insert(txtList, {
                     color = color,
-                    text = currentTxt
+                    text = currentTxt,
+                    width = imgui.CalcTextSize(currentTxt).x,
+                    height = imgui.CalcTextSize(currentTxt).y
                 })
                 currentTxt = c
             end
@@ -93,7 +114,9 @@ local function textToColorAndText(text, nocolor)
     if(currentTxt ~= "") then
         table.insert(txtList, {
             color = color,
-            text = currentTxt
+            text = currentTxt,
+            width = imgui.CalcTextSize(currentTxt).x,
+            height = imgui.CalcTextSize(currentTxt).y
         })
     end
 
@@ -230,8 +253,13 @@ local function addMessage(username, message, id, color)
         color = color,
         message = message,
         sentTime = os.time(),
-        id = #M.chatMessages + 1
+        id = #M.chatMessages + 1,
+        currentWidth = imgui.CalcTextSize(username .. ": ").x,
+        currentHeight = imgui.CalcTextSize(username .. ": ").y
     }
+    if messageTable.color then
+        messageTable.color = imgui.ImVec4(messageTable.color[0]/255, messageTable.color[1]/255, messageTable.color[2]/255, (messageTable.color[3] or 127)/255)
+    end
 
     table.insert(M.chatMessages, messageTable)
 
@@ -244,8 +272,33 @@ local function addMessage(username, message, id, color)
     end
 end
 
+local totalChatHeight = 0
+
+local function recalculateChatHeight(windowWidth)
+    local scrollbarSize = imgui.GetStyle().ScrollbarSize
+    totalChatHeight = 0
+    for k,message in pairs(M.chatMessages) do
+        local columnWidth = windowWidth - 42
+        columnWidth = columnWidth - scrollbarSize
+        columnWidth = columnWidth - 10
+
+        local currentWidth = message.currentWidth
+        local currentHeight = message.currentHeight
+        for _, v in ipairs(message.message) do
+            if (currentWidth + v.width <= columnWidth) then
+            else
+                currentWidth = 0
+                currentHeight = currentHeight + v.height
+            end
+            v.cachedHeight = currentHeight
+        end
+        totalChatHeight = totalChatHeight + currentHeight
+    end
+end
 
 local scrollbarVisible = false
+local lastWindowWidth = 0
+local lastMessageCount = 0
 
 --- Render the IMGUI windows on each frame.
 local function render()
@@ -279,19 +332,22 @@ local function render()
             columnWidth = columnWidth - 10
             
             if message.color then
-                imgui.TextColored(imgui.ImVec4(message.color[0]/255, message.color[1]/255, message.color[2]/255, (message.color[3] or 127)/255), message.username)
+                    imgui.TextColored(message.color, message.username)
                 imgui.SameLine()
             else
                 imgui.Text(message.username .. ": ")
                 imgui.SameLine()
             end
-            
-            local currentWidth = imgui.CalcTextSize(message.username .. ": ").x
+      
+            local currentWidth = message.currentWidth
 
             for _, v in ipairs(message.message) do
-                if (currentWidth + imgui.CalcTextSize(v.text).x <= columnWidth) then imgui.SameLine(currentWidth)
-                else currentWidth = 0 end
-                currentWidth = currentWidth + imgui.CalcTextSize(v.text).x
+                if (currentWidth + v.width <= columnWidth) then
+                    imgui.SameLine(currentWidth)
+                else
+                    currentWidth = 0
+                end
+                currentWidth = currentWidth + v.width
                 imgui.TextColored(v.color, v.text)
             end
 
@@ -312,14 +368,14 @@ local function render()
         scrollToBottom = false
     end
 
-    imgui.PushStyleVar2(imgui.StyleVar_FramePadding, imgui.ImVec2(2, 2))
-    imgui.PushStyleVar2(imgui.StyleVar_ItemSpacing, imgui.ImVec2(2, 0))
-    imgui.PushStyleVar2(imgui.StyleVar_CellPadding, imgui.ImVec2(0, 0))
+    imgui.PushStyleVar2(imgui.StyleVar_FramePadding, useTempVec2(2, 2))
+    imgui.PushStyleVar2(imgui.StyleVar_ItemSpacing, useTempVec2(2, 0))
+    imgui.PushStyleVar2(imgui.StyleVar_CellPadding, useTempVec2(0, 0))
     imgui.SetCursorPosY(imgui.GetWindowHeight() - 35)
 
-    imgui.PushStyleColor2(imgui.Col_FrameBg, imgui.ImVec4(UI.settings.colors.primaryColor.x, UI.settings.colors.primaryColor.y, UI.settings.colors.primaryColor.z, 1))
+    imgui.PushStyleColor2(imgui.Col_FrameBg, useTempVec4(UI.settings.colors.primaryColor.x, UI.settings.colors.primaryColor.y, UI.settings.colors.primaryColor.z, 1))
 
-    if imgui.BeginChild1("ChatInput", imgui.ImVec2(0, 30), false) then
+    if imgui.BeginChild1("ChatInput", useTempVec2(0, 30), false) then
         imgui.SetNextItemWidth(imgui.GetWindowWidth() - 25)
         local flags = 0
         flags = flags + imgui.InputTextFlags_EnterReturnsTrue
@@ -355,7 +411,7 @@ local function render()
         heightOffset = 40
 
         if not forceBottom then
-            imgui.SetCursorPos(imgui.ImVec2(imgui.GetWindowWidth() - (scrollbarVisible and scrollbarSize or 0) - 24, imgui.GetWindowHeight() - 60))
+            imgui.SetCursorPos(useTempVec2(imgui.GetWindowWidth() - (scrollbarVisible and scrollbarSize or 0) - 24, imgui.GetWindowHeight() - 60))
             if utils.imageButton(UI.uiIcons.down.texId, 16) then
                 scrollToBottom = true
                 wasMessageSent = false

--- a/lua/ge/extensions/beammp/ui/utils.lua
+++ b/lua/ge/extensions/beammp/ui/utils.lua
@@ -12,6 +12,14 @@ local M = {}
 
 local imgui = ui_imgui
 
+local ImVec4One = imgui.ImVec4(1, 1, 1, 1)
+local ImVec4Zero = imgui.ImVec4(0, 0, 0, 0)
+local buttonSize = imgui.ImVec2(1, 1)
+
+local Col_Button = imgui.GetStyleColorVec4(imgui.Col_Button)
+local Col_ButtonActive = imgui.GetStyleColorVec4(imgui.Col_ButtonActive)
+local Col_ButtonHovered = imgui.GetStyleColorVec4(imgui.Col_ButtonHovered)
+
 --- Creates an image button with the specified texture ID, size, and colors using IMGUI.
 --- @param texID number The ID of the texture to use for the button.
 --- @param size number The size of the button.
@@ -21,14 +29,17 @@ local imgui = ui_imgui
 --- @return boolean Returns true if the button was clicked, false otherwise.
 M.imageButton = function(texID, size, color, activeColor, hoveredColor)
     --local colors = imgui.GetStyle()[1].Colors
-    color = color or imgui.GetStyleColorVec4(imgui.Col_Button)
-    activeColor = activeColor or imgui.GetStyleColorVec4(imgui.Col_ButtonActive)
-    hoveredColor = hoveredColor or imgui.GetStyleColorVec4(imgui.Col_ButtonHovered)
+    color = color or Col_Button
+    activeColor = activeColor or Col_ButtonActive
+    hoveredColor = hoveredColor or Col_ButtonHovered
 
     -- Remove background
-    imgui.PushStyleColor2(imgui.Col_Button, imgui.ImVec4(0, 0, 0, 0))
-    local buttonSize = imgui.ImVec2(size, size)
-    if imgui.ImageButton("##ImageButton" .. tostring(texID), texID, buttonSize, imgui.ImVec2Zero, imgui.ImVec2One, imgui.ImVec4(0, 0, 0, 0), imgui.ImVec4(1, 1, 1, 1)) then
+    imgui.PushStyleColor2(imgui.Col_Button, ImVec4Zero)
+
+    buttonSize.x = size
+    buttonSize.y = size
+
+    if imgui.ImageButton("##ImageButton" .. tostring(texID), texID, buttonSize, imgui.ImVec2Zero, imgui.ImVec2One, ImVec4Zero, ImVec4One) then
         imgui.PopStyleColor()
         return true
     end

--- a/lua/ge/extensions/nodesGE.lua
+++ b/lua/ge/extensions/nodesGE.lua
@@ -29,7 +29,7 @@ local function sendNodes(data, gameVehicleID)
 	if MPGameNetwork.launcherConnected() then
 		local serverVehicleID = MPVehicleGE.getServerVehicleID(gameVehicleID)
 		if serverVehicleID and MPVehicleGE.isOwn(gameVehicleID) then
-			MPGameNetwork.send(MPHelpers.generatePacketBuffer('Xn',serverVehicleID,data))
+			MPGameNetwork.send(MPNetworkHelpers.generatePacketBuffer('Xn',serverVehicleID,data))
 		end
 	end
 end
@@ -43,7 +43,7 @@ local function sendBreakGroups(data, gameVehicleID)
 	if MPGameNetwork.launcherConnected() then
 		local serverVehicleID = MPVehicleGE.getServerVehicleID(gameVehicleID)
 		if serverVehicleID and MPVehicleGE.isOwn(gameVehicleID) then
-			MPGameNetwork.send(MPHelpers.generatePacketBuffer('Xg',serverVehicleID,data))
+			MPGameNetwork.send(MPNetworkHelpers.generatePacketBuffer('Xg',serverVehicleID,data))
 		end
 	end
 end
@@ -59,7 +59,7 @@ local function sendControllerData(data, gameVehicleID)
 			end
 			data = jsonEncode(decodedData)
 
-			MPGameNetwork.send(MPHelpers.generatePacketBuffer('Xc',serverVehicleID,data))
+			MPGameNetwork.send(MPNetworkHelpers.generatePacketBuffer('Xc',serverVehicleID,data))
 		end
 	end
 end

--- a/lua/ge/extensions/nodesGE.lua
+++ b/lua/ge/extensions/nodesGE.lua
@@ -11,15 +11,11 @@
 
 local M = {}
 
-
 --- Called on specified interval by MPUpdatesGE to simulate our own tick event to collect data.
 local function tick()
-	local ownMap = MPVehicleGE.getOwnMap()
-	for i,v in pairs(ownMap) do
-		local veh = be:getObjectByID(i)
-		if veh then
-			--veh:queueLuaCommand("nodesVE.getNodes()")
-			veh:queueLuaCommand("nodesVE.getBreakGroups()")
+	for i,v in pairs(MPVehicleGE.getPlayerVehicleObjects(MPConfig.getPlayerServerID())) do
+		if v then
+			v:queueLuaCommand("nodesVE.getBreakGroups()")
 		end
 	end
 end

--- a/lua/ge/extensions/nodesGE.lua
+++ b/lua/ge/extensions/nodesGE.lua
@@ -29,7 +29,7 @@ local function sendNodes(data, gameVehicleID)
 	if MPGameNetwork.launcherConnected() then
 		local serverVehicleID = MPVehicleGE.getServerVehicleID(gameVehicleID)
 		if serverVehicleID and MPVehicleGE.isOwn(gameVehicleID) then
-			MPGameNetwork.send('Xn:'..serverVehicleID..":"..data)
+			MPGameNetwork.send(MPHelpers.generatePacketBuffer('Xn',serverVehicleID,data))
 		end
 	end
 end
@@ -43,7 +43,7 @@ local function sendBreakGroups(data, gameVehicleID)
 	if MPGameNetwork.launcherConnected() then
 		local serverVehicleID = MPVehicleGE.getServerVehicleID(gameVehicleID)
 		if serverVehicleID and MPVehicleGE.isOwn(gameVehicleID) then
-			MPGameNetwork.send('Xg:'..serverVehicleID..":"..data)
+			MPGameNetwork.send(MPHelpers.generatePacketBuffer('Xg',serverVehicleID,data))
 		end
 	end
 end
@@ -58,7 +58,8 @@ local function sendControllerData(data, gameVehicleID)
 				decodedData.vehID = MPVehicleGE.getServerVehicleID(decodedData.vehID)
 			end
 			data = jsonEncode(decodedData)
-			MPGameNetwork.send('Xc:'..serverVehicleID..":"..data)
+
+			MPGameNetwork.send(MPHelpers.generatePacketBuffer('Xc',serverVehicleID,data))
 		end
 	end
 end

--- a/lua/ge/extensions/nodesGE.lua
+++ b/lua/ge/extensions/nodesGE.lua
@@ -69,7 +69,7 @@ end
 -- @param serverVehicleID string The VehicleID according to the server.
 local function applyNodes(data, serverVehicleID)
 	local gameVehicleID = MPVehicleGE.getGameVehicleID(serverVehicleID) or -1
-	local veh = be:getObjectByID(gameVehicleID)
+	local veh = getObjectByID(gameVehicleID)
 	if veh then
 		veh:queueLuaCommand("nodesVE.applyNodes(mime.unb64(\'".. MPHelpers.b64encode(data) .."\'))")
 	end
@@ -81,7 +81,7 @@ end
 -- @param serverVehicleID string The VehicleID according to the server.
 local function applyBreakGroups(data, serverVehicleID)
 	local gameVehicleID = MPVehicleGE.getGameVehicleID(serverVehicleID) or -1
-	local veh = be:getObjectByID(gameVehicleID)
+	local veh = getObjectByID(gameVehicleID)
 	if veh then
 		veh:queueLuaCommand("nodesVE.applyBreakGroups(mime.unb64(\'".. MPHelpers.b64encode(data) .."\'))")
 	end

--- a/lua/ge/extensions/positionGE.lua
+++ b/lua/ge/extensions/positionGE.lua
@@ -205,12 +205,7 @@ end
 -- @param ping number The Ping value
 local function setPing(ping)
 	local p = ping/1000
-	for i = 0, be:getObjectCount() - 1 do
-		local veh = be:getObject(i)
-		if veh then
-			veh:queueLuaCommand("positionVE.setPing("..p..")")
-		end
-	end
+	be:queueAllObjectLua("positionVE.setPing("..p..")")
 end
 
 --- This function is to allow for the setting of the vehicle/objects position.

--- a/lua/ge/extensions/positionGE.lua
+++ b/lua/ge/extensions/positionGE.lua
@@ -55,7 +55,7 @@ local function sendVehiclePosRot(data, gameVehicleID)
 	if MPGameNetwork.launcherConnected() then
 		local serverVehicleID = MPVehicleGE.getServerVehicleID(gameVehicleID) -- Get serverVehicleID
 		if serverVehicleID and MPVehicleGE.isOwn(gameVehicleID) then -- If serverVehicleID not null and player own vehicle
-			MPGameNetwork.send(MPHelpers.generatePacketBuffer('Zp',serverVehicleID,data))
+			MPGameNetwork.send(MPNetworkHelpers.generatePacketBuffer('Zp',serverVehicleID,data))
 		end
 	end
 end

--- a/lua/ge/extensions/positionGE.lua
+++ b/lua/ge/extensions/positionGE.lua
@@ -11,6 +11,7 @@
 
 local M = {}
 
+local targetGameSpeed = 1
 local actualSimSpeed = 1
 
 --[[
@@ -54,17 +55,7 @@ local function sendVehiclePosRot(data, gameVehicleID)
 	if MPGameNetwork.launcherConnected() then
 		local serverVehicleID = MPVehicleGE.getServerVehicleID(gameVehicleID) -- Get serverVehicleID
 		if serverVehicleID and MPVehicleGE.isOwn(gameVehicleID) then -- If serverVehicleID not null and player own vehicle
-			local decoded = jsonDecode(data)
-			local simspeedReal = simTimeAuthority.getReal()
-
-			decoded.isTransitioning = (simTimeAuthority.get() ~= simspeedReal) or nil
-
-			simspeedReal = simTimeAuthority.getPause() and 0 or simspeedReal -- set velocities to 0 if game is paused
-
-			for k,v in pairs(decoded.vel) do decoded.vel[k] = v*simspeedReal end
-			for k,v in pairs(decoded.rvel) do decoded.rvel[k] = v*simspeedReal end
-
-			MPGameNetwork.send('Zp:'..serverVehicleID..":"..jsonEncode(decoded))
+			MPGameNetwork.send('Zp:'..serverVehicleID..":"..data)
 		end
 	end
 end
@@ -76,17 +67,6 @@ end
 local function applyPos(decoded, serverVehicleID)
 	local vehicle = MPVehicleGE.getVehicleByServerID(serverVehicleID)
 	if not vehicle then log('E', 'applyPos', 'Could not find vehicle by ID '..serverVehicleID) return end
-
-
-	local simspeedFraction = 1
-	local gameSpeed = simTimeAuthority.getReal()
-	if gameSpeed > 0 then
-		simspeedFraction = 1/gameSpeed
-		for k,v in pairs(decoded.vel) do decoded.vel[k] = v*simspeedFraction end
-		for k,v in pairs(decoded.rvel) do decoded.rvel[k] = v*simspeedFraction end
-	end
-
-	decoded.localSimspeed = simspeedFraction
 
 	local veh = getObjectByID(vehicle.gameVehicleID)
 	if veh then -- vehicle already spawned, send data
@@ -277,6 +257,15 @@ local function onPreRender(dt)
 	end
 end
 
+local function onUpdate(dtReal, dtSim, dtRaw)
+	setActualSimSpeed(dtSim/dtRaw)
+	local simSpeed = simTimeAuthority.getReal() * (simTimeAuthority.getPause() and 0 or 1)
+	if targetGameSpeed ~= simSpeed then
+		be:queueAllObjectLua("positionVE.setGameSpeed("..simSpeed..")")
+	end
+	targetGameSpeed = simSpeed
+end
+
 --- This function is used to reset the positional update smoother when it is disabled
 local function onSettingsChanged()
 	if not settings.getValue("enablePosSmoother") then -- nil/false
@@ -296,6 +285,7 @@ M.setPing                     = setPing
 M.setActualSimSpeed           = setActualSimSpeed
 M.getActualSimSpeed           = getActualSimSpeed
 M.onPreRender                 = onPreRender
+M.onUpdate                    = onUpdate
 M.onSettingsChanged           = onSettingsChanged
 M.posSmoother                 = POSSMOOTHER -- debug entry
 M.onInit = function() setExtensionUnloadMode(M, "manual") end

--- a/lua/ge/extensions/positionGE.lua
+++ b/lua/ge/extensions/positionGE.lua
@@ -258,12 +258,14 @@ local function onPreRender(dt)
 end
 
 local function onUpdate(dtReal, dtSim, dtRaw)
-	setActualSimSpeed(dtSim/dtRaw)
-	local simSpeed = simTimeAuthority.getReal() * (simTimeAuthority.getPause() and 0 or 1)
-	if targetGameSpeed ~= simSpeed then
-		be:queueAllObjectLua("positionVE.setGameSpeed("..simSpeed..")")
+	if MPGameNetwork and MPGameNetwork.launcherConnected() then
+		setActualSimSpeed(dtSim/dtRaw)
+		local simSpeed = simTimeAuthority.getReal() * (simTimeAuthority.getPause() and 0 or 1)
+		if targetGameSpeed ~= simSpeed then
+			be:queueAllObjectLua("positionVE.setGameSpeed("..simSpeed..")")
+		end
+		targetGameSpeed = simSpeed
 	end
-	targetGameSpeed = simSpeed
 end
 
 --- This function is used to reset the positional update smoother when it is disabled

--- a/lua/ge/extensions/positionGE.lua
+++ b/lua/ge/extensions/positionGE.lua
@@ -88,7 +88,7 @@ local function applyPos(decoded, serverVehicleID)
 
 	decoded.localSimspeed = simspeedFraction
 
-	local veh = be:getObjectByID(vehicle.gameVehicleID)
+	local veh = getObjectByID(vehicle.gameVehicleID)
 	if veh then -- vehicle already spawned, send data
 		if veh.mpVehicleType == nil then
 			veh:queueLuaCommand("MPVehicleVE.setVehicleType('R')")
@@ -219,7 +219,7 @@ end
 -- @param y number Coordinate y
 -- @param z number Coordinate z
 local function setPosition(gameVehicleID, x, y, z) -- TODO: this is only here because there seems to be no way to set vehicle position in vehicle lua without resetting the vehicle
-	local veh = be:getObjectByID(gameVehicleID)
+	local veh = getObjectByID(gameVehicleID)
 	veh:setPositionNoPhysicsReset(Point3F(x, y, z))
 end
 
@@ -228,7 +228,7 @@ local function setPositionRotationVelocity(gameVehicleID, positionData) -- this 
 	local newRot = positionData.rot
 	local vel = positionData.vel
 	local rvel = positionData.rvel
-	local veh = be:getObjectByID(gameVehicleID)
+	local veh = getObjectByID(gameVehicleID)
 
 	local localVel = veh:getVelocity()
 	local vehVel = positionData.vehVel

--- a/lua/ge/extensions/positionGE.lua
+++ b/lua/ge/extensions/positionGE.lua
@@ -74,7 +74,7 @@ local function applyPos(data, serverVehicleID)
 			veh:queueLuaCommand("MPVehicleVE.setVehicleType('R')")
 			veh.mpVehicleType = 'R'
 		end
-		be:sendToMailbox("vehPosPckt" .. vehicle.gameVehicleID ,data)
+		be:sendToMailbox("vehPosPckt" .. serverVehicleID ,data)
 	end
 
 	local owner = vehicle:getOwner()

--- a/lua/ge/extensions/positionGE.lua
+++ b/lua/ge/extensions/positionGE.lua
@@ -62,9 +62,9 @@ end
 
 
 --- This function serves to send the position data received for another players vehicle from GE to VE, where it is handled.
--- @param decoded table The data to be applied to a vehicle, needs to contain "pos", "rot", "vel", "rvel", "ping" and "tim"
+-- @param encoded json The data to be applied to a vehicle, needs to contain "pos", "rot", "vel", "rvel", "ping" and "tim"
 -- @param serverVehicleID string The VehicleID according to the server.
-local function applyPos(decoded, serverVehicleID)
+local function applyPos(data, serverVehicleID)
 	local vehicle = MPVehicleGE.getVehicleByServerID(serverVehicleID)
 	if not vehicle then log('E', 'applyPos', 'Could not find vehicle by ID '..serverVehicleID) return end
 
@@ -74,19 +74,26 @@ local function applyPos(decoded, serverVehicleID)
 			veh:queueLuaCommand("MPVehicleVE.setVehicleType('R')")
 			veh.mpVehicleType = 'R'
 		end
-		veh:queueLuaCommand("positionVE.setVehiclePosRot(mime.unb64(\'".. MPHelpers.b64encode(jsonEncode(decoded)) .."\'))")
+		be:sendToMailbox("vehPosPckt" .. vehicle.gameVehicleID ,data)
 	end
-	local deltaDt = math.max((decoded.tim or 0) - (vehicle.lastDt or 0), 0.001)
-	vehicle.lastDt = decoded.tim
-	local ping = math.floor(decoded.ping*1000) -- (d.ping-deltaDt)
-
-	vehicle.ping = ping
-	vehicle.fps = 1/deltaDt
-	vehicle.position = Point3F(decoded.pos[1],decoded.pos[2],decoded.pos[3])
-	vehicle.rotation = quat(decoded.rot[1],decoded.rot[2],decoded.rot[3],decoded.rot[4])
 
 	local owner = vehicle:getOwner()
-	if owner then UI.setPlayerPing(owner.name, ping) end-- Send ping to UI
+	if owner and not owner.hasUpdatedPing or not veh then -- only update once per frame per player unless the vehicle is not spawned, spawned vehicles already gets their position and rotation in MPvehicleGE
+		local decoded = jsonDecode(data)
+		local deltaDt = math.max((decoded.tim or 0) - (vehicle.lastDt or 0), 0.001)
+		vehicle.lastDt = decoded.tim
+
+		vehicle.position:set(decoded.pos[1],decoded.pos[2],decoded.pos[3])
+		vehicle.rotation:set(decoded.rot[1],decoded.rot[2],decoded.rot[3],decoded.rot[4])
+
+		if owner and not owner.updatedPing then
+			local ping = math.floor(decoded.ping*1000) -- (d.ping-deltaDt)
+			UI.setPlayerPing(owner.name, ping)
+			owner.ping = ping
+			owner.fps = 1/deltaDt
+		end-- Send ping to UI
+		owner.hasUpdatedPing = true
+	end
 end
 
 --- Tries to delay the positional update execution to match the average update interval from this vehicle
@@ -170,11 +177,11 @@ local function handle(rawData)
 	end
 
 	if code == 'p' then
-		local decoded = jsonDecode(data)
 		if settings.getValue("enablePosSmoother") then
+			local decoded = jsonDecode(data)
 			smoothPosExec(serverVehicleID, decoded)
 		else
-			applyPos(decoded, serverVehicleID)
+			applyPos(data, serverVehicleID)
 		end
 	else
 		log('W', 'handle', "Received unknown packet '"..tostring(code).."'! ".. rawData)
@@ -249,7 +256,7 @@ local function onPreRender(dt)
 			POSSMOOTHER[serverVehicleID].executed_last:stopAndReset()
 			POSSMOOTHER[serverVehicleID].executed = true
 			POSSMOOTHER[serverVehicleID].last_executed_tim = data.data.tim
-			applyPos(data.data, serverVehicleID)
+			applyPos(jsonEncode(data.data), serverVehicleID)
 			
 		elseif timedif > 60000 then -- seconds. vehicle potentially removed. rem entry
 			POSSMOOTHER[serverVehicleID] = nil
@@ -265,6 +272,10 @@ local function onUpdate(dtReal, dtSim, dtRaw)
 			be:queueAllObjectLua("positionVE.setGameSpeed("..simSpeed..")")
 		end
 		targetGameSpeed = simSpeed
+		local players = getPlayers()
+		for k,player in pairs(players) do
+			player.hasUpdatedPing = false
+		end
 	end
 end
 

--- a/lua/ge/extensions/positionGE.lua
+++ b/lua/ge/extensions/positionGE.lua
@@ -55,7 +55,7 @@ local function sendVehiclePosRot(data, gameVehicleID)
 	if MPGameNetwork.launcherConnected() then
 		local serverVehicleID = MPVehicleGE.getServerVehicleID(gameVehicleID) -- Get serverVehicleID
 		if serverVehicleID and MPVehicleGE.isOwn(gameVehicleID) then -- If serverVehicleID not null and player own vehicle
-			MPGameNetwork.send('Zp:'..serverVehicleID..":"..data)
+			MPGameNetwork.send(MPHelpers.generatePacketBuffer('Zp',serverVehicleID,data))
 		end
 	end
 end

--- a/lua/ge/extensions/positionGE.lua
+++ b/lua/ge/extensions/positionGE.lua
@@ -39,11 +39,9 @@ local TIMER = (HighPerfTimer or hptimer) -- game own timer that is much more acc
 
 --- Called on specified interval by positionGE to simulate our own tick event to collect data.
 local function tick()
-	local ownMap = MPVehicleGE.getOwnMap() -- Get map of own vehicles
-	for i,v in pairs(ownMap) do -- For each own vehicle
-		local veh = be:getObjectByID(i) -- Get vehicle
-		if veh then
-			veh:queueLuaCommand("positionVE.getVehicleRotation()")
+	for i,v in pairs(MPVehicleGE.getPlayerVehicleObjects(MPConfig.getPlayerServerID())) do
+		if v then
+			v:queueLuaCommand("positionVE.getVehicleRotation()")
 		end
 	end
 end

--- a/lua/vehicle/extensions/BeamMP/MPVehicleVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPVehicleVE.lua
@@ -5,6 +5,7 @@
 local M = {}
 
 v.mpVehicleType = "L" -- we assume vehicles are local (they're set to remove once we receive pos data from the server)
+v.mpServerID = ""
 
 local keyStates = {} -- table of keys and their states, used as a reference
 local keysToPoll = {} -- list of keys we want to poll for state changes
@@ -57,6 +58,10 @@ local function setVehicleType(x)
   v.mpVehicleType = x
 end
 
+local function setServerID(id)
+  v.mpServerID = id
+end
+
 local function updateGFX(dtReal)
 	if v.mpVehicleType == 'R' and hydros.enableFFB then -- disable ffb if it got enabled by a reset
 		-- trigger a check that will set FFBID to -1
@@ -84,6 +89,7 @@ M.updateGFX = updateGFX
 M.onExtensionLoaded    = onExtensionLoaded
 
 M.setVehicleType       = setVehicleType
+M.setServerID          = setServerID
 
 --M.getKeyState = getKeyState
 --M.addKeyEventListener = addKeyEventListener

--- a/lua/vehicle/extensions/BeamMP/positionVE.lua
+++ b/lua/vehicle/extensions/BeamMP/positionVE.lua
@@ -86,6 +86,7 @@ local raccErrorSmoother = newVectorSmoothing(50)            -- Smoother for angu
 local timeOffsetSmoother = newTemporalSmoothingNonLinear(1) -- Smoother for getting average time offset
 
 -- Persistent data
+local lastMailboxVersion = 0
 local framesSinceReset = 0
 local timer = 0
 local ownPing = 0
@@ -192,11 +193,47 @@ end
 
 
 
+local function updateRemoteData()
+	local currentMailBoxVersion = obj:getLastMailboxVersion("vehPosPckt" .. objectId)
+	if lastMailboxVersion ~= currentMailBoxVersion then
+		local jsonData = obj:getLastMailbox("vehPosPckt" .. objectId)
+		local pr = jsonDecode(jsonData)
+		local pos  = vec3(pr.pos)
+		local vel  = vec3(pr.vel)
+		local rot  = quat(pr.rot)
+		local rvel = vec3(pr.rvel)
+		local tim  = pr.tim
+		local ping = pr.ping
+		local simspeedfraction = 1/simSpeedReal
+
+		if not tim then return end
+		if remoteData.timer > tim then return end
+
+		local remoteDT = max(tim - remoteData.timer, 0.001)
+
+		remoteData.pos = pos
+		remoteData.rot = rot
+		remoteData.acc = limitVecLength((vel - remoteData.vel)/remoteDT, maxAcc)
+		remoteData.racc = limitVecLength((rvel - remoteData.rvel)/remoteDT, maxRacc)
+		remoteData.vel = vel*simspeedfraction
+		remoteData.rvel = rvel*simspeedfraction
+		remoteData.timer = tim
+		remoteData.timeOffset = timer-tim - ownPing/2 - ping/2 - lastDT
+		remoteData.recTime = timer
+		remoteData.localSimspeed = math.min(simspeedfraction, 25)
+	end
+	lastMailboxVersion = currentMailBoxVersion
+end
+
+
+
 local function updateGFX(dt)
 	dt = dt * (remoteData.localSimspeed or 1)
 	timer = timer + dt
 	lastDT = dt
 	framesSinceReset = framesSinceReset + 1
+
+	updateRemoteData()
 
 	-- If there is no received data, or data is older than timeout, do nothing
 	if not remoteData.pos or (timer-remoteData.recTime) > packetTimeout then return end
@@ -382,34 +419,6 @@ end
 
 
 
-local function setVehiclePosRot(data)
-
-	local pr   = jsonDecode(data)
-	local pos  = vec3(pr.pos)
-	local vel  = vec3(pr.vel)
-	local rot  = quat(pr.rot)
-	local rvel = vec3(pr.rvel)
-	local tim  = pr.tim
-	local ping = pr.ping
-	local simspeedfraction = 1/simSpeedReal
-
-	if not tim then return end
-	if remoteData.timer > tim then return end
-
-	local remoteDT = max(tim - remoteData.timer, 0.001)
-
-	remoteData.pos = pos
-	remoteData.rot = rot
-	remoteData.acc = limitVecLength((vel - remoteData.vel)/remoteDT, maxAcc)
-	remoteData.racc = limitVecLength((rvel - remoteData.rvel)/remoteDT, maxRacc)
-	remoteData.vel = vel*simspeedfraction
-	remoteData.rvel = rvel*simspeedfraction
-	remoteData.timer = tim
-	remoteData.timeOffset = timer-tim - ownPing/2 - ping/2 - lastDT
-	remoteData.recTime = timer
-	remoteData.localSimspeed = math.min(simspeedfraction, 25)
-end
-
 local function onInit()
 	enablePhysicsStepHook()
 end
@@ -424,7 +433,6 @@ M.onExtensionLoaded  = onInit
 M.onPhysicsStep      = update
 M.updateGFX          = updateGFX
 M.getVehicleRotation = getVehicleRotation
-M.setVehiclePosRot   = setVehiclePosRot
 M.setPing            = setPing
 M.setGameSpeed       = setGameSpeed
 

--- a/lua/vehicle/extensions/BeamMP/positionVE.lua
+++ b/lua/vehicle/extensions/BeamMP/positionVE.lua
@@ -230,12 +230,12 @@ end
 
 
 local function updateGFX(dt)
+	updateRemoteData()
 	dt = dt * (remoteData.localSimspeed or 1)
 	timer = timer + dt
 	lastDT = dt
 	framesSinceReset = framesSinceReset + 1
 
-	updateRemoteData()
 
 	-- If there is no received data, or data is older than timeout, do nothing
 	if not remoteData.pos or (timer-remoteData.recTime) > packetTimeout then return end

--- a/lua/vehicle/extensions/BeamMP/positionVE.lua
+++ b/lua/vehicle/extensions/BeamMP/positionVE.lua
@@ -118,6 +118,8 @@ local smoothRvel = vec3(0,0,0)
 local physHandlerAdded = false
 
 local debugDrawer = obj.debugDrawProxy
+
+local simSpeedReal = 1
 -- ============= VARIABLES =============
 
 
@@ -180,28 +182,9 @@ local function onReset()
 	framesSinceReset = 0
 end
 
-local physcounter = 0
-local physstart = 0
 
-local physmult = 1
 
 local function update(dtSim)
-	if physcounter == 0 then
-		physstart = os.clock()
-	end
-	physcounter = physcounter+1
-	if physcounter == 2000 then
-		physcounter = 0
-		local physend = os.clock()
-		local physdiff = physend - physstart
-		if playerInfo.firstPlayerSeated then
-			physmult = 1/physdiff -- (physdiff == 0) and 0 or 1/physdiff
-			--print(tostring(physmult*100) .."% realtime")
-			obj:queueGameEngineLua("positionGE.setActualSimSpeed("..tostring(physmult)..")")
-		end
-	end
-
-
 	-- Smooth vehicle velocity to prevent vibrating
 	smoothVel = localVelSmoother:get(vec3(obj:getVelocity()), dtSim)
 	smoothRvel = localRvelSmoother:get(vec3(obj:getPitchAngularVelocity(), obj:getRollAngularVelocity(), obj:getYawAngularVelocity()), dtSim)
@@ -408,7 +391,7 @@ local function setVehiclePosRot(data)
 	local rvel = vec3(pr.rvel)
 	local tim  = pr.tim
 	local ping = pr.ping
-	local simspeedfraction = pr.localSimspeed
+	local simspeedfraction = 1/simSpeedReal
 
 	if not tim then return end
 	if remoteData.timer > tim then return end
@@ -419,8 +402,8 @@ local function setVehiclePosRot(data)
 	remoteData.rot = rot
 	remoteData.acc = limitVecLength((vel - remoteData.vel)/remoteDT, maxAcc)
 	remoteData.racc = limitVecLength((rvel - remoteData.rvel)/remoteDT, maxRacc)
-	remoteData.vel = vel
-	remoteData.rvel = rvel
+	remoteData.vel = vel*simspeedfraction
+	remoteData.rvel = rvel*simspeedfraction
 	remoteData.timer = tim
 	remoteData.timeOffset = timer-tim - ownPing/2 - ping/2 - lastDT
 	remoteData.recTime = timer
@@ -431,7 +414,9 @@ local function onInit()
 	enablePhysicsStepHook()
 end
 
-
+local function setGameSpeed(speed)
+	simSpeedReal = speed
+end
 
 M.onReset            = onReset
 M.onInit             = onInit
@@ -441,6 +426,7 @@ M.updateGFX          = updateGFX
 M.getVehicleRotation = getVehicleRotation
 M.setVehiclePosRot   = setVehiclePosRot
 M.setPing            = setPing
+M.setGameSpeed       = setGameSpeed
 
 
 return M

--- a/lua/vehicle/extensions/BeamMP/positionVE.lua
+++ b/lua/vehicle/extensions/BeamMP/positionVE.lua
@@ -194,9 +194,11 @@ end
 
 
 local function updateRemoteData()
-	local currentMailBoxVersion = obj:getLastMailboxVersion("vehPosPckt" .. objectId)
+	if not v.mpServerID or v.mpServerID == "" then return end
+	local mailBoxName = "vehPosPckt" .. v.mpServerID
+	local currentMailBoxVersion = obj:getLastMailboxVersion(mailBoxName)
 	if lastMailboxVersion ~= currentMailBoxVersion then
-		local jsonData = obj:getLastMailbox("vehPosPckt" .. objectId)
+		local jsonData = obj:getLastMailbox(mailBoxName)
 		local pr = jsonDecode(jsonData)
 		local pos  = vec3(pr.pos)
 		local vel  = vec3(pr.vel)

--- a/lua/vehicle/extensions/BeamMP/positionVE.lua
+++ b/lua/vehicle/extensions/BeamMP/positionVE.lua
@@ -239,9 +239,6 @@ local function updateGFX(dt)
 
 	-- If there is no received data, or data is older than timeout, do nothing
 	if not remoteData.pos or (timer-remoteData.recTime) > packetTimeout then return end
-	
-	-- Since the line above returns end if there is no remote data we know this vehicle should be remote if this runs
-	if v.mpVehicleType == "L" then v.mpVehicleType = "R" end
 
 	-- Local vehicle data
 	local vehRot = quatFromDir(-vec3(obj:getDirectionVector()), vec3(obj:getDirectionVectorUp()))

--- a/lua/vehicle/extensions/BeamMP/positionVE.lua
+++ b/lua/vehicle/extensions/BeamMP/positionVE.lua
@@ -402,9 +402,8 @@ local function getVehicleRotation()
 	local vel = smoothVel + cog:cross(rvel)
 	if vel ~= vel then log('E','getVehicleRotation', 'skipped invalid velocity values') return end
 
-	-- disabled because the GE implementation of slowmo sync is instant, but doesn't account for low fps compensation
-	--vel = vel * physmult
-	--rvel = rvel * physmult
+	vel = vel * simSpeedReal
+	rvel = rvel * simSpeedReal
 
 	local tempTable = {
 		pos = {pos.x, pos.y, pos.z},


### PR DESCRIPTION
I've gone through and tried to clear up a lot of the Lua garbage that gets created, and additionally optimized a few things,

here is what's changed

MPVehicleGE onPreRender loop is cleaned up and now only creates garbage if the nametags distance has changed, this is done by caching nametags, queues, vectors, colors and changing vector math to the garbage free set functions as well as using the XYZ versions of the getPosition/rotation functions.

all be:getObjectByID() calls are switched to the cached getObjectByID() function.

Position packets are not decoded and encoded in GE anymore when sending and receiving, we used it to adjust velocity to game speed when in slow motion, that is now done in VE, received packets are also changed to use mailboxes instead of queues, so we can give the mailbox the position string directly, which saves more string operations,

Receive should now allow 100s of vehicles without garbage stutters, that's assuming the computer can handle that many vehicles ofc xD, sending is still causing quite a few stutters with that many vehicles, but the direct VE sockets Stefan's been working on will fully get rid of that.

Creating packet strings is now done with string buffers, which saves some string operations, it half's the garbage per sent packet.

I've also cleaned up the Imgui chat so it produces significantly less lua garbage, each message is reduced from 320 bytes to 0, so now a filled out imgui chat won't cause slowdowns anymore