### PR TITLE
Fix spam delete for left click action

### DIFF
--- a/ui/modules/apps/BeamMP-PlayerList/app.js
+++ b/ui/modules/apps/BeamMP-PlayerList/app.js
@@ -191,8 +191,8 @@ app.controller("PlayerList", ['$scope', '$filter', 'Settings', function ($scope,
 							bngApi.engineLua(`
 								for id, veh in pairs(MPVehicleGE.getVehicles()) do
 									if veh.ownerName == require("mime").unb64('` + btoa(parsedList[i].name) + `') then
-										local veh = getObjectByID(veh.gameVehicleID)
-										if veh then veh:delete() end
+										local vehicle = getObjectByID(veh.gameVehicleID)
+										if vehicle then vehicle:delete() end
 									end
 								end
 						`)}

--- a/ui/modules/apps/BeamMP-PlayerList/app.js
+++ b/ui/modules/apps/BeamMP-PlayerList/app.js
@@ -191,7 +191,8 @@ app.controller("PlayerList", ['$scope', '$filter', 'Settings', function ($scope,
 							bngApi.engineLua(`
 								for id, veh in pairs(MPVehicleGE.getVehicles()) do
 									if veh.ownerName == require("mime").unb64('` + btoa(parsedList[i].name) + `') then
-										be:getObjectByID(veh.gameVehicleID):delete()
+										local veh = getObjectByID(veh.gameVehicleID)
+										if veh then veh:delete() end
 									end
 								end
 						`)}

--- a/ui/modules/apps/BeamMP-PlayerList/app.js
+++ b/ui/modules/apps/BeamMP-PlayerList/app.js
@@ -187,13 +187,14 @@ app.controller("PlayerList", ['$scope', '$filter', 'Settings', function ($scope,
 						nameCell.setAttribute("onclick", "viewPlayer('"+parsedList[i].name+"')");
 						break;
 					case 3:
-						bngApi.engineLua(`
-							for id, veh in pairs(MPVehicleGE.getVehicles()) do
-								if veh.ownerName == require("mime").unb64('` + btoa(parsedList[i].name) + `') then
-									be:getObjectByID(veh.gameVehicleID):delete()
+						nameCell.onclick = function() {
+							bngApi.engineLua(`
+								for id, veh in pairs(MPVehicleGE.getVehicles()) do
+									if veh.ownerName == require("mime").unb64('` + btoa(parsedList[i].name) + `') then
+										be:getObjectByID(veh.gameVehicleID):delete()
+									end
 								end
-							end
-						`)
+						`)}
 						break;
 					case 4:
 						nameCell.setAttribute("onclick", "restorePlayerVehicle('"+parsedList[i].name+"')");


### PR DESCRIPTION
This PR fixes everyone's vehicles being spam deleted every frame when the player list left click action is set to "Delete all vehicles".