### PR TITLE
Update velocityVE.lua

### DIFF
--- a/lua/vehicle/extensions/BeamMP/velocityVE.lua
+++ b/lua/vehicle/extensions/BeamMP/velocityVE.lua
@@ -180,7 +180,7 @@ local function onInit()
 		calcCOG()
 	end
 
-	log('M', 'onInit', "velocityVE init, physicsFPS: "..physicsFPS..", parentNode: "..parentNode)
+	log('M', 'onInit', "velocityVE init, physicsFPS: "..physicsFPS..", parentNode: "..tostring(parentNode))
 end
 
 local function onReset()


### PR DESCRIPTION
prevents crash when parentNode is nil during initialization

Added tostring() to the parentNode log call in onInit() to prevent a "concatenate nil value" error when no valid reference node connection is found.