### PR TITLE
Add unreliable (UDP) event support

### DIFF
--- a/lua/ge/extensions/MPGameNetwork.lua
+++ b/lua/ge/extensions/MPGameNetwork.lua
@@ -291,6 +291,14 @@ function TriggerServerEvent(name, data)
 	M.send('E:'..name..':'..data)
 end
 
+--- Triggers an unreliable server event with the specified name and data.
+-- @tparam string name - The name of the event
+-- @tparam string data - The data to be sent with the event
+-- @usage TriggerServerEventUnreliable(`<name>`, `<data>`)
+function TriggerServerEventUnreliable(name, data)
+	M.send('e:'..name..':'..data)
+end
+
 --- Triggers a local client event with the specified name and data.
 -- @tparam string name - The name of the event
 -- @tparam string data - The data to be sent with the event
@@ -468,6 +476,7 @@ local HandleNetwork = {
 	['L'] = function(params) playerLeft(params) end, -- A player left
 	['S'] = function(params) sessionData(params) end, -- Update Session Data
 	['E'] = function(params) handleEvents(params) end, -- Event For another Resource
+	['e'] = function(params) handleEvents(params) end,
 	['T'] = function(params) quitMP(params) end, -- Player Kicked Event (old, doesn't contain reason)
 	['K'] = function(params) quitMP(params) end, -- Player Kicked Event (new, contains reason)
 	['C'] = function(params) UI.chatMessage(params) end, -- Chat Message Event


### PR DESCRIPTION
Adds an unreliable counterpart to the existing reliable event system, allowing mods to send events over UDP instead of TCP.

### New API

**Server-side Lua:**
- `MP.TriggerClientEventUnreliable(PlayerID, EventName, Data)` — UDP delivery
- `MP.TriggerClientEventJsonUnreliable(PlayerID, EventName, Data)` — JSON variant

**Client-side Lua:**
- `TriggerServerEventUnreliable(EventName, Data)` — sends `e:EventName:Data` to server

### How it works

Reliable events use `E` (uppercase) as the packet prefix, unreliable use `e` (lowercase). Both follow the same code path — the only difference is TCP vs UDP transport.

The launcher skips the >1KB compressed-size TCP upgrade for `e` packets so they stay on UDP regardless of payload size.

### Why

The existing event system only supports reliable delivery. This forces TCP retransmission for every event, which is unnecessary overhead for data that doesn't need guaranteed delivery. This adds the option to opt into UDP where appropriate.

See also: BeamMP/BeamMP-Server#493, BeamMP/BeamMP-Launcher#253