### PR TITLE
Switched to batch based mod loading

### DIFF
--- a/lua/ge/extensions/MPModManager.lua
+++ b/lua/ge/extensions/MPModManager.lua
@@ -148,13 +148,22 @@ end
 --- Load the Servers mods, these are put in by the BeamMP Launcher
 local function loadServerMods()
 	log('W', 'loadServerMods', 'loadServerMods')
-	
+
 	local modsDir = FS:findFiles("/mods/multiplayer", "*.zip", -1, false, false)
-	for _, modPath in pairs(modsDir) do
-		core_modmanager.workOffChangedMod(modPath, 'added')
-	end
-	checkAllMods()
-	MPCoreNetwork.requestMap()
+
+    core_jobsystem.create(function(job)
+		local amount = #modsDir
+        local batchSize = 5
+		local core_modmanager_workOffChangedMod = core_modmanager.workOffChangedMod
+        for i = 1, amount, batchSize do
+            for j = i, math.min(i + batchSize - 1, amount) do
+                core_modmanager_workOffChangedMod(modsDir[j], 'added')
+            end
+            job.sleep(0)
+        end
+        checkAllMods()
+        MPCoreNetwork.requestMap()
+    end)
 end
 
 --- Verify that the servers mods have been loaded by the game.


### PR DESCRIPTION
Instead of everything at once

Derived from @coops924 (https://github.com/BeamMP/BeamMP/issues/803#issuecomment-4435219031)

Seemingly fixes a crash that can occur when BeamNG is overloaded by mod updates. Should fix #803 

