### PR TITLE
Guard position sync against NaN on both send and receive

### DIFF
--- a/lua/vehicle/extensions/BeamMP/positionVE.lua
+++ b/lua/vehicle/extensions/BeamMP/positionVE.lua
@@ -380,7 +380,17 @@ local function getVehicleRotation()
 	local cog = velocityVE.cogRel:rotated(rot)
 	local pos = vec3(obj:getPosition()) + cog
 	local vel = smoothVel + cog:cross(rvel)
-	if vel ~= vel then log('E','getVehicleRotation', 'skipped invalid velocity values') return end
+	-- Skip sending if ANY value is NaN. During rapid instability the game can produce NaN
+	-- position/rotation (not just velocity); sending it teleports this car to NaN on every
+	-- other client -- it "disappears" for them until the owner reloads. Checking only the
+	-- velocity (the old behaviour) let NaN positions through.
+	if pos.x ~= pos.x or pos.y ~= pos.y or pos.z ~= pos.z
+		or vel.x ~= vel.x or vel.y ~= vel.y or vel.z ~= vel.z
+		or rot.x ~= rot.x or rot.y ~= rot.y or rot.z ~= rot.z or rot.w ~= rot.w
+		or rvel.x ~= rvel.x or rvel.y ~= rvel.y or rvel.z ~= rvel.z then
+		log('E','getVehicleRotation', 'skipped invalid (NaN) position/velocity values')
+		return
+	end
 
 	-- disabled because the GE implementation of slowmo sync is instant, but doesn't account for low fps compensation
 	--vel = vel * physmult
@@ -411,6 +421,12 @@ local function setVehiclePosRot(data)
 	local simspeedfraction = pr.localSimspeed
 
 	if not tim then return end
+	-- Reject NaN/garbage so a bad packet can't fling this remote car off-world
+	-- (defensive: older senders don't have the send-side NaN guard).
+	if pos.x ~= pos.x or pos.y ~= pos.y or pos.z ~= pos.z
+		or rot.x ~= rot.x or rot.y ~= rot.y or rot.z ~= rot.z or rot.w ~= rot.w then
+		return
+	end
 	if remoteData.timer > tim then return end
 
 	local remoteDT = max(tim - remoteData.timer, 0.001)


### PR DESCRIPTION
### Problem

During rapid instability BeamNG can produce **NaN position/rotation**, not just NaN velocity. The send-side guard in `positionVE.getVehicleRotation` only checked the velocity (`if vel ~= vel then ... return end`), so a NaN pose was still broadcast — teleporting the car to NaN-land on **every other client** (it "disappears" for them until the owner reloads the vehicle; the code's own comment at the top of the function describes this failure mode).

### Fix

- **Send side:** skip the send if *any* component of pos/vel/rot/rvel is NaN (component-wise `x ~= x` checks — cheap, no allocations).
- **Receive side:** reject a packet whose pos/rot contains NaN in `setVehiclePosRot`, since older senders don't have the send-side guard.

Wire format unchanged; a NaN frame is simply skipped and the next healthy update (typically the next tick) resumes sync.

### How this was found

Reproduced on a LAN fork of BeamMP with an intentionally broken third-party vehicle that NaN-cascades on spawn (the affected car vanished for the other player until reload); with the guard the car stays in place through the instability. Running in that fork for weeks of sessions.

### Transparency

This fix comes from an AI-assisted fork: the bug was found and the patch written with the help of an AI coding tool (Claude), then tested by a human in real multiplayer sessions. Given this project's policy on AI-generated code, it's submitted as a **draft** for the maintainers to decide — happy to close it if that's not wanted, or for a maintainer to re-implement independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
