### PR TITLE
fixed ui being set to the wrong layout

### DIFF
--- a/lua/ge/extensions/beammp/multiplayer.lua
+++ b/lua/ge/extensions/beammp/multiplayer.lua
@@ -141,7 +141,6 @@ local function onWorldReadyState(state)
 	if state == 2 then
 		if MPCoreNetwork and MPCoreNetwork.isMPSession() then
 			log('M', 'onWorldReadyState', 'Setting game state to BeamMP multiplayer.')
-			core_gamestate.setGameState('multiplayer', 'multiplayer', 'multiplayer')
 			local spawnDefaultGroups = { "CameraSpawnPoints", "PlayerSpawnPoints", "PlayerDropPoints", "spawnpoints" }
 
 			for i, v in pairs(spawnDefaultGroups) do


### PR DESCRIPTION
should fix the missing ui elements and no ui when closing the radial menu

setGameState was set in two different places, and one was setting it to the old layout, i've just removed the one that was setting it wrong,
the correct on is located in runPostJoin in MPCoreNetwork